### PR TITLE
feat: add GitHub Copilot CLI agent support

### DIFF
--- a/server/cmd/tma1-server/main.go
+++ b/server/cmd/tma1-server/main.go
@@ -171,6 +171,11 @@ func main() {
 	defer openclawCancel()
 	go tw.StartOpenClawScanner(openclawCtx)
 
+	// Start Copilot CLI session scanner (discovers ~/.copilot/session-state/*/events.jsonl).
+	copilotCLICtx, copilotCLICancel := context.WithCancel(context.Background())
+	defer copilotCLICancel()
+	go tw.StartCopilotCLIScanner(copilotCLICtx)
+
 	// Step 7: start HTTP server (dashboard + API proxy).
 	llmCfg := handler.LLMConfig{
 		APIKey:   cfg.LLMAPIKey,
@@ -200,6 +205,7 @@ func main() {
 		flowCancel()
 		codexCancel()
 		openclawCancel()
+		copilotCLICancel()
 		tw.StopAll()
 
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)

--- a/server/internal/transcript/copilot_cli.go
+++ b/server/internal/transcript/copilot_cli.go
@@ -20,6 +20,15 @@ const (
 	copilotCLISessionPfx   = "cp:"
 )
 
+// escapeSQLStringFull escapes both single quotes and backslashes for SQL string literals.
+// GreptimeDB interprets backslash as an escape character in string literals,
+// so Windows paths like C:\Users must be escaped as C:\\Users.
+func escapeSQLStringFull(s string) string {
+	s = strings.ReplaceAll(s, "\\", "\\\\")
+	s = strings.ReplaceAll(s, "'", "''")
+	return s
+}
+
 // StartCopilotCLIScanner periodically scans ~/.copilot/session-state/ for active
 // events.jsonl files and starts watching any new ones. GitHub Copilot CLI stores
 // session events as JSONL files in per-session directories.
@@ -137,10 +146,31 @@ func (w *Watcher) tailCopilotCLIFile(ctx context.Context, watcherKey, sessionID,
 	}
 	defer f.Close()
 
+	fctx := &copilotCLIContext{sessionID: sessionID}
+
 	// Skip backfill if this session was already ingested (prevents duplicates on restart).
+	// But always read the first line to populate context (model, cwd).
 	dbSID := copilotCLISessionPfx + sessionID
-	if w.copilotCLISessionExists(dbSID) {
-		// Seek to end — only process new lines written after this point.
+	skipBackfill := w.copilotCLISessionExists(dbSID)
+	if skipBackfill {
+		// Read first line to extract session context (cwd, model), then seek to end.
+		firstReader := bufio.NewReader(f)
+		if firstLine, err := firstReader.ReadString('\n'); err == nil {
+			trimmed := strings.TrimSpace(firstLine)
+			if trimmed != "" {
+				var ev copilotCLIEvent
+				if json.Unmarshal([]byte(trimmed), &ev) == nil && ev.Type == "session.start" {
+					var data struct {
+						Context struct {
+							CWD string `json:"cwd"`
+						} `json:"context"`
+					}
+					if json.Unmarshal(ev.Data, &data) == nil {
+						fctx.cwd = data.Context.CWD
+					}
+				}
+			}
+		}
 		if _, err := f.Seek(0, io.SeekEnd); err != nil {
 			w.logger.Warn("copilot-cli seek to end failed", "session", sessionID, "error", err)
 		}
@@ -148,7 +178,6 @@ func (w *Watcher) tailCopilotCLIFile(ctx context.Context, watcherKey, sessionID,
 
 	reader := bufio.NewReader(f)
 	var buf strings.Builder
-	fctx := &copilotCLIContext{sessionID: sessionID}
 	idleCount := 0
 	const maxIdlePolls = 600 // 5 minutes at 500ms
 
@@ -276,12 +305,10 @@ func (w *Watcher) handleCopilotCLISessionStart(ts time.Time, ev copilotCLIEvent,
 
 	fctx.cwd = data.Context.CWD
 
-	// Build metadata with context info.
+	// Store branch and repo in metadata (skip git_root to avoid backslash SQL issues).
 	metadata := map[string]string{
 		"copilot_version": data.CopilotVersion,
-		"git_root":        data.Context.GitRoot,
 		"branch":          data.Context.Branch,
-		"head_commit":     data.Context.HeadCommit,
 		"repository":      data.Context.Repository,
 	}
 
@@ -487,6 +514,33 @@ func (w *Watcher) copilotCLISessionExists(dbSessionID string) bool {
 	return resp.StatusCode == 200 && strings.Contains(string(body), "\"rows\":[")
 }
 
+// execSQLDebug wraps execSQL with additional logging for debugging insert failures.
+func (w *Watcher) execSQLDebug(sql, eventType, sessionID string) {
+	form := url.Values{}
+	form.Set("sql", sql)
+
+	ctx, cancel := context.WithTimeout(context.Background(), insertTimeout)
+	defer cancel()
+
+	req, err := newPostRequest(ctx, w.sqlURL, form)
+	if err != nil {
+		w.logger.Warn("copilot-cli insert: create request failed", "event", eventType, "session", sessionID, "error", err)
+		return
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		w.logger.Warn("copilot-cli insert failed", "event", eventType, "session", sessionID, "error", err)
+		return
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode != 200 {
+		w.logger.Warn("copilot-cli insert non-200", "event", eventType, "session", sessionID, "status", resp.StatusCode, "body", string(body))
+	}
+}
+
 // insertCopilotCLIMessage inserts a conversation message into tma1_messages.
 func (w *Watcher) insertCopilotCLIMessage(dbSessionID string, ts time.Time, messageType, role, content, model, toolName, toolUseID string, usage *msgUsage) {
 	msTs := ts.UnixMilli()
@@ -512,7 +566,7 @@ func (w *Watcher) insertCopilotCLIMessage(dbSessionID string, ts time.Time, mess
 			escapeSQLString(dbSessionID),
 			escapeSQLString(messageType),
 			escapeSQLString(role),
-			escapeSQLString(truncate(content, maxContentLen)),
+			escapeSQLStringFull(truncate(content, maxContentLen)),
 			escapeSQLString(model),
 			escapeSQLString(toolName),
 			escapeSQLString(toolUseID),
@@ -529,7 +583,7 @@ func (w *Watcher) insertCopilotCLIMessage(dbSessionID string, ts time.Time, mess
 			escapeSQLString(dbSessionID),
 			escapeSQLString(messageType),
 			escapeSQLString(role),
-			escapeSQLString(truncate(content, maxContentLen)),
+			escapeSQLStringFull(truncate(content, maxContentLen)),
 			escapeSQLString(model),
 			escapeSQLString(toolName),
 			escapeSQLString(toolUseID),
@@ -592,19 +646,19 @@ func (w *Watcher) insertCopilotCLIHookEventFull(ts time.Time, fctx *copilotCLICo
 		escapeSQLString(dbSessionID),
 		escapeSQLString(eventType),
 		copilotCLIAgentSource,
-		escapeSQLString(truncate(toolName, 256)),
-		escapeSQLString(truncate(toolInput, maxToolInput)),
-		escapeSQLString(truncate(toolResult, maxToolContent)),
+		escapeSQLStringFull(truncate(toolName, 256)),
+		escapeSQLStringFull(truncate(toolInput, maxToolInput)),
+		escapeSQLStringFull(truncate(toolResult, maxToolContent)),
 		escapeSQLString(toolUseID),
 		escapeSQLString(agentID),
 		escapeSQLString(agentType),
-		escapeSQLString(truncate(cwd, 512)),
+		escapeSQLStringFull(truncate(cwd, 512)),
 		escapeSQLString(dbSessionID),
-		escapeSQLString(metadataJSON),
+		escapeSQLStringFull(metadataJSON),
 	)
 	go func() {
 		insertSem <- struct{}{}
 		defer func() { <-insertSem }()
-		w.execSQL(sql)
+		w.execSQLDebug(sql, eventType, fctx.sessionID)
 	}()
 }

--- a/server/internal/transcript/copilot_cli.go
+++ b/server/internal/transcript/copilot_cli.go
@@ -288,6 +288,19 @@ func (w *Watcher) processCopilotCLILine(sessionID, line string, seen map[string]
 		seen[ev.ID] = struct{}{}
 	}
 
+	// Split on session.start: if the JSONL contains multiple logical sessions
+	// (appended across restarts), update fctx.sessionID to create separate DB sessions.
+	if ev.Type == "session.start" {
+		var startData struct {
+			SessionID string `json:"sessionId"`
+		}
+		if json.Unmarshal(ev.Data, &startData) == nil && startData.SessionID != "" && startData.SessionID != fctx.sessionID {
+			fctx.sessionID = startData.SessionID
+			fctx.model = ""
+			fctx.cwd = ""
+		}
+	}
+
 	ts, _ := time.Parse(time.RFC3339Nano, ev.Timestamp)
 	if ts.IsZero() {
 		ts = time.Now()

--- a/server/internal/transcript/copilot_cli.go
+++ b/server/internal/transcript/copilot_cli.go
@@ -1,0 +1,574 @@
+package transcript
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const (
+	copilotCLIScanInterval = 10 * time.Second
+	copilotCLIActiveAge    = 10 * time.Minute
+	copilotCLIAgentSource  = "copilot_cli"
+	copilotCLISessionPfx   = "cp:"
+)
+
+// StartCopilotCLIScanner periodically scans ~/.copilot/session-state/ for active
+// events.jsonl files and starts watching any new ones. GitHub Copilot CLI stores
+// session events as JSONL files in per-session directories.
+func (w *Watcher) StartCopilotCLIScanner(ctx context.Context) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		w.logger.Warn("copilot-cli scanner: cannot determine home directory", "error", err)
+		return
+	}
+	baseDir := filepath.Join(homeDir, ".copilot", "session-state")
+	w.logger.Info("copilot-cli session scanner started", "path", baseDir)
+
+	ticker := time.NewTicker(copilotCLIScanInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if _, err := os.Stat(baseDir); err == nil {
+				w.scanCopilotCLISessions(baseDir)
+			}
+		}
+	}
+}
+
+func (w *Watcher) scanCopilotCLISessions(baseDir string) {
+	now := time.Now()
+
+	// Prune stopped watchers to prevent unbounded memory growth.
+	w.mu.Lock()
+	var stoppedCount int
+	for key, sw := range w.sessions {
+		if sw.stopped && strings.HasPrefix(key, copilotCLISessionPfx) {
+			stoppedCount++
+		}
+	}
+	if stoppedCount > 50 {
+		for key, sw := range w.sessions {
+			if sw.stopped && strings.HasPrefix(key, copilotCLISessionPfx) {
+				delete(w.sessions, key)
+			}
+		}
+	}
+	w.mu.Unlock()
+
+	entries, err := os.ReadDir(baseDir)
+	if err != nil {
+		return
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		eventsFile := filepath.Join(baseDir, entry.Name(), "events.jsonl")
+		info, err := os.Stat(eventsFile)
+		if err != nil || now.Sub(info.ModTime()) > copilotCLIActiveAge {
+			continue
+		}
+		sessionID := entry.Name()
+		watcherKey := copilotCLISessionPfx + sessionID
+		w.watchCopilotCLI(watcherKey, sessionID, eventsFile)
+	}
+}
+
+func (w *Watcher) watchCopilotCLI(watcherKey, sessionID, filePath string) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	existing, ok := w.sessions[watcherKey]
+	if ok && !existing.stopped {
+		return // already watching
+	}
+
+	var seen map[string]struct{}
+	if ok && existing.seen != nil {
+		seen = existing.seen
+	} else {
+		seen = make(map[string]struct{})
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	sw := &sessionWatch{cancel: cancel, seen: seen}
+	w.sessions[watcherKey] = sw
+
+	go w.tailCopilotCLIFile(ctx, watcherKey, sessionID, filePath, seen)
+	w.logger.Info("watching copilot-cli session", "session", sessionID, "file", filePath)
+}
+
+func (w *Watcher) tailCopilotCLIFile(ctx context.Context, watcherKey, sessionID, filePath string, seen map[string]struct{}) {
+	defer func() {
+		w.mu.Lock()
+		if sw, ok := w.sessions[watcherKey]; ok {
+			sw.stopped = true
+		}
+		w.mu.Unlock()
+	}()
+
+	var f *os.File
+	for i := 0; i < 5; i++ {
+		var err error
+		f, err = os.Open(filePath) //nolint:gosec
+		if err == nil {
+			break
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(pollInterval):
+		}
+	}
+	if f == nil {
+		return
+	}
+	defer f.Close()
+
+	reader := bufio.NewReader(f)
+	var buf strings.Builder
+	fctx := &copilotCLIContext{sessionID: sessionID}
+	idleCount := 0
+	const maxIdlePolls = 600 // 5 minutes at 500ms
+
+	for {
+		line, err := reader.ReadString('\n')
+		if len(line) > 0 {
+			idleCount = 0
+			buf.WriteString(line)
+			if strings.HasSuffix(line, "\n") {
+				trimmed := strings.TrimSpace(buf.String())
+				buf.Reset()
+				if trimmed != "" {
+					w.processCopilotCLILine(sessionID, trimmed, seen, fctx)
+				}
+			}
+			continue
+		}
+		if err == io.EOF {
+			if !fctx.live {
+				fctx.live = true
+			}
+			idleCount++
+			if idleCount > maxIdlePolls {
+				w.logger.Info("copilot-cli session idle, stopping watcher", "session", sessionID)
+				return
+			}
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(pollInterval):
+			}
+			continue
+		}
+		if err != nil {
+			w.logger.Debug("copilot-cli file read error", "session", sessionID, "error", err)
+			return
+		}
+	}
+}
+
+// copilotCLIEvent is the common envelope for all Copilot CLI JSONL events.
+type copilotCLIEvent struct {
+	Type      string          `json:"type"`
+	Data      json.RawMessage `json:"data"`
+	ID        string          `json:"id"`
+	Timestamp string          `json:"timestamp"`
+	ParentID  *string         `json:"parentId"`
+}
+
+// copilotCLIContext tracks per-file state during parsing.
+type copilotCLIContext struct {
+	sessionID string
+	model     string // current model (updated by session.start and session.model_change)
+	cwd       string
+	live      bool // true after initial backfill completes
+}
+
+// dbSessionID returns the namespaced session ID for database storage.
+func (c *copilotCLIContext) dbSessionID() string {
+	return copilotCLISessionPfx + c.sessionID
+}
+
+func (w *Watcher) processCopilotCLILine(sessionID, line string, seen map[string]struct{}, fctx *copilotCLIContext) {
+	var ev copilotCLIEvent
+	if err := json.Unmarshal([]byte(line), &ev); err != nil {
+		return
+	}
+
+	// Dedup by event ID.
+	if ev.ID != "" {
+		if _, ok := seen[ev.ID]; ok {
+			return
+		}
+		seen[ev.ID] = struct{}{}
+	}
+
+	ts, _ := time.Parse(time.RFC3339Nano, ev.Timestamp)
+	if ts.IsZero() {
+		ts = time.Now()
+	}
+
+	switch ev.Type {
+	case "session.start":
+		w.handleCopilotCLISessionStart(ts, ev, fctx)
+	case "session.shutdown":
+		w.insertCopilotCLIHookEvent(ts, fctx, "SessionEnd", "", "", "", "", nil)
+	case "session.model_change":
+		w.handleCopilotCLIModelChange(ts, ev, seen, fctx)
+	case "session.task_complete":
+		w.insertCopilotCLIHookEvent(ts, fctx, "TaskCompleted", "", "", "", "", nil)
+	case "user.message":
+		w.handleCopilotCLIUserMessage(ts, ev, seen, fctx)
+	case "assistant.message":
+		w.handleCopilotCLIAssistantMessage(ts, ev, seen, fctx)
+	case "tool.execution_start":
+		w.handleCopilotCLIToolStart(ts, ev, fctx)
+	case "tool.execution_complete":
+		w.handleCopilotCLIToolComplete(ts, ev, fctx)
+	case "subagent.started":
+		w.handleCopilotCLISubagentStart(ts, ev, fctx)
+	case "subagent.completed":
+		w.handleCopilotCLISubagentComplete(ts, ev, fctx)
+	case "skill.invoked":
+		w.handleCopilotCLISkillInvoked(ts, ev, fctx)
+	// Skip: hook.start, hook.end, session.warning, system.notification,
+	// session.mode_changed, session.context_changed, assistant.turn_start, assistant.turn_end
+	}
+}
+
+func (w *Watcher) handleCopilotCLISessionStart(ts time.Time, ev copilotCLIEvent, fctx *copilotCLIContext) {
+	var data struct {
+		SessionID      string `json:"sessionId"`
+		CopilotVersion string `json:"copilotVersion"`
+		Context        struct {
+			CWD        string `json:"cwd"`
+			GitRoot    string `json:"gitRoot"`
+			Branch     string `json:"branch"`
+			HeadCommit string `json:"headCommit"`
+			Repository string `json:"repository"`
+		} `json:"context"`
+	}
+	if err := json.Unmarshal(ev.Data, &data); err != nil {
+		return
+	}
+
+	fctx.cwd = data.Context.CWD
+
+	// Build metadata with context info.
+	metadata := map[string]string{
+		"copilot_version": data.CopilotVersion,
+		"git_root":        data.Context.GitRoot,
+		"branch":          data.Context.Branch,
+		"head_commit":     data.Context.HeadCommit,
+		"repository":      data.Context.Repository,
+	}
+
+	w.insertCopilotCLIHookEventWithCWD(ts, fctx, "SessionStart", "", "", "", "", metadata, data.Context.CWD)
+	if fctx.live {
+		w.broadcastHookEvent(fctx.dbSessionID(), "SessionStart", "", "", "", "", "", "")
+	}
+}
+
+func (w *Watcher) handleCopilotCLIModelChange(ts time.Time, ev copilotCLIEvent, seen map[string]struct{}, fctx *copilotCLIContext) {
+	var data struct {
+		NewModel string `json:"newModel"`
+	}
+	if err := json.Unmarshal(ev.Data, &data); err != nil || data.NewModel == "" {
+		return
+	}
+	fctx.model = data.NewModel
+
+	// Insert synthetic model message (same pattern as Codex).
+	w.insertCopilotCLIMessage(fctx.dbSessionID(), ts, "assistant", "assistant", "", fctx.model, "", "", nil)
+}
+
+func (w *Watcher) handleCopilotCLIUserMessage(ts time.Time, ev copilotCLIEvent, seen map[string]struct{}, fctx *copilotCLIContext) {
+	var data struct {
+		Content string `json:"content"`
+	}
+	if err := json.Unmarshal(ev.Data, &data); err != nil {
+		return
+	}
+	content := strings.TrimSpace(data.Content)
+	if content == "" {
+		return
+	}
+	w.insertCopilotCLIMessage(fctx.dbSessionID(), ts, "user", "user", content, fctx.model, "", "", nil)
+	if fctx.live {
+		w.broadcastHookEvent(fctx.dbSessionID(), "UserPromptSubmit", "", "", "", "", "", "")
+	}
+}
+
+func (w *Watcher) handleCopilotCLIAssistantMessage(ts time.Time, ev copilotCLIEvent, seen map[string]struct{}, fctx *copilotCLIContext) {
+	var data struct {
+		Content       string `json:"content"`
+		ReasoningText string `json:"reasoningText"`
+		OutputTokens  int64  `json:"outputTokens"`
+		RequestID     string `json:"requestId"`
+	}
+	if err := json.Unmarshal(ev.Data, &data); err != nil {
+		return
+	}
+
+	// Update model from tool.execution_complete if available (handled elsewhere).
+	// outputTokens is per-response; no inputTokens available in this event.
+	var usage *msgUsage
+	if data.OutputTokens > 0 {
+		usage = &msgUsage{OutputTokens: data.OutputTokens}
+	}
+
+	// Emit reasoning text as thinking message.
+	reasoning := strings.TrimSpace(data.ReasoningText)
+	if reasoning != "" {
+		w.insertCopilotCLIMessage(fctx.dbSessionID(), ts, "thinking", "assistant", reasoning, fctx.model, "", "", nil)
+	}
+
+	// Emit content as assistant message (may be empty when only tool calls).
+	content := strings.TrimSpace(data.Content)
+	if content != "" {
+		w.insertCopilotCLIMessage(fctx.dbSessionID(), ts, "assistant", "assistant", content, fctx.model, "", "", usage)
+	} else if usage != nil {
+		// Even with empty content, record usage on a synthetic message so cost tracking works.
+		w.insertCopilotCLIMessage(fctx.dbSessionID(), ts, "assistant", "assistant", "", fctx.model, "", "", usage)
+	}
+}
+
+func (w *Watcher) handleCopilotCLIToolStart(ts time.Time, ev copilotCLIEvent, fctx *copilotCLIContext) {
+	var data struct {
+		ToolCallID string          `json:"toolCallId"`
+		ToolName   string          `json:"toolName"`
+		Arguments  json.RawMessage `json:"arguments"`
+	}
+	if err := json.Unmarshal(ev.Data, &data); err != nil {
+		return
+	}
+
+	argsStr := truncate(string(data.Arguments), maxToolInput)
+	w.insertCopilotCLIHookEvent(ts, fctx, "PreToolUse", data.ToolName, argsStr, data.ToolCallID, "", nil)
+	if fctx.live {
+		w.broadcastHookEvent(fctx.dbSessionID(), "PreToolUse", data.ToolName, argsStr, data.ToolCallID, "", "", "")
+	}
+}
+
+func (w *Watcher) handleCopilotCLIToolComplete(ts time.Time, ev copilotCLIEvent, fctx *copilotCLIContext) {
+	var data struct {
+		ToolCallID string `json:"toolCallId"`
+		Model      string `json:"model"`
+		Success    bool   `json:"success"`
+		Result     struct {
+			Content string `json:"content"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(ev.Data, &data); err != nil {
+		return
+	}
+
+	// Update model from tool completion context.
+	if data.Model != "" {
+		fctx.model = data.Model
+	}
+
+	eventType := "PostToolUse"
+	if !data.Success {
+		eventType = "PostToolUseFailure"
+	}
+
+	resultStr := truncate(data.Result.Content, maxToolContent)
+	w.insertCopilotCLIHookEvent(ts, fctx, eventType, "", "", data.ToolCallID, resultStr, nil)
+	if fctx.live {
+		w.broadcastHookEvent(fctx.dbSessionID(), eventType, "", "", data.ToolCallID, resultStr, "", "")
+	}
+}
+
+func (w *Watcher) handleCopilotCLISubagentStart(ts time.Time, ev copilotCLIEvent, fctx *copilotCLIContext) {
+	var data struct {
+		ToolCallID  string `json:"toolCallId"`
+		AgentName   string `json:"agentName"`
+		Description string `json:"agentDescription"`
+	}
+	if err := json.Unmarshal(ev.Data, &data); err != nil {
+		return
+	}
+
+	agentID := data.ToolCallID
+	agentType := data.AgentName
+
+	metadata := map[string]string{"description": truncate(data.Description, 512)}
+	w.insertCopilotCLIHookEventWithAgent(ts, fctx, "SubagentStart", agentID, agentType, metadata)
+	if fctx.live {
+		w.broadcastHookEvent(fctx.dbSessionID(), "SubagentStart", "", "", "", "", agentID, agentType)
+	}
+}
+
+func (w *Watcher) handleCopilotCLISubagentComplete(ts time.Time, ev copilotCLIEvent, fctx *copilotCLIContext) {
+	var data struct {
+		ToolCallID     string `json:"toolCallId"`
+		AgentName      string `json:"agentName"`
+		Model          string `json:"model"`
+		TotalToolCalls int    `json:"totalToolCalls"`
+		TotalTokens    int64  `json:"totalTokens"`
+		DurationMs     int64  `json:"durationMs"`
+	}
+	if err := json.Unmarshal(ev.Data, &data); err != nil {
+		return
+	}
+
+	agentID := data.ToolCallID
+	agentType := data.AgentName
+
+	metadata := map[string]string{
+		"model":            data.Model,
+		"total_tool_calls": fmt.Sprintf("%d", data.TotalToolCalls),
+		"total_tokens":     fmt.Sprintf("%d", data.TotalTokens),
+		"duration_ms":      fmt.Sprintf("%d", data.DurationMs),
+	}
+	w.insertCopilotCLIHookEventWithAgent(ts, fctx, "SubagentStop", agentID, agentType, metadata)
+	if fctx.live {
+		w.broadcastHookEvent(fctx.dbSessionID(), "SubagentStop", "", "", "", "", agentID, agentType)
+	}
+}
+
+func (w *Watcher) handleCopilotCLISkillInvoked(ts time.Time, ev copilotCLIEvent, fctx *copilotCLIContext) {
+	var data struct {
+		Skill string `json:"skill"`
+	}
+	if err := json.Unmarshal(ev.Data, &data); err != nil || data.Skill == "" {
+		return
+	}
+	metadata := map[string]string{"skill": data.Skill}
+	w.insertCopilotCLIHookEvent(ts, fctx, "SkillInvoked", "", "", "", "", metadata)
+}
+
+// insertCopilotCLIMessage inserts a conversation message into tma1_messages.
+func (w *Watcher) insertCopilotCLIMessage(dbSessionID string, ts time.Time, messageType, role, content, model, toolName, toolUseID string, usage *msgUsage) {
+	msTs := ts.UnixMilli()
+	for {
+		prev := lastInsertTS.Load()
+		next := msTs
+		if next <= prev {
+			next = prev + 1
+		}
+		if lastInsertTS.CompareAndSwap(prev, next) {
+			msTs = next
+			break
+		}
+	}
+
+	var sql string
+	if usage != nil {
+		sql = fmt.Sprintf(
+			"INSERT INTO tma1_messages (ts, session_id, message_type, \"role\", content, model, tool_name, tool_use_id, "+
+				"input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens) "+
+				"VALUES (%d, '%s', '%s', '%s', '%s', '%s', '%s', '%s', %d, %d, %d, %d)",
+			msTs,
+			escapeSQLString(dbSessionID),
+			escapeSQLString(messageType),
+			escapeSQLString(role),
+			escapeSQLString(truncate(content, maxContentLen)),
+			escapeSQLString(model),
+			escapeSQLString(toolName),
+			escapeSQLString(toolUseID),
+			usage.InputTokens,
+			usage.OutputTokens,
+			usage.CacheReadTokens,
+			usage.CacheCreationTokens,
+		)
+	} else {
+		sql = fmt.Sprintf(
+			"INSERT INTO tma1_messages (ts, session_id, message_type, \"role\", content, model, tool_name, tool_use_id) "+
+				"VALUES (%d, '%s', '%s', '%s', '%s', '%s', '%s', '%s')",
+			msTs,
+			escapeSQLString(dbSessionID),
+			escapeSQLString(messageType),
+			escapeSQLString(role),
+			escapeSQLString(truncate(content, maxContentLen)),
+			escapeSQLString(model),
+			escapeSQLString(toolName),
+			escapeSQLString(toolUseID),
+		)
+	}
+
+	go func() {
+		insertSem <- struct{}{}
+		defer func() { <-insertSem }()
+		w.execSQL(sql)
+	}()
+}
+
+// insertCopilotCLIHookEvent inserts a hook event into tma1_hook_events.
+func (w *Watcher) insertCopilotCLIHookEvent(ts time.Time, fctx *copilotCLIContext, eventType, toolName, toolInput, toolUseID, toolResult string, metadata map[string]string) {
+	w.insertCopilotCLIHookEventFull(ts, fctx, eventType, toolName, toolInput, toolUseID, toolResult, "", "", metadata, "")
+}
+
+func (w *Watcher) insertCopilotCLIHookEventWithCWD(ts time.Time, fctx *copilotCLIContext, eventType, toolName, toolInput, toolUseID, toolResult string, metadata map[string]string, cwd string) {
+	w.insertCopilotCLIHookEventFull(ts, fctx, eventType, toolName, toolInput, toolUseID, toolResult, "", "", metadata, cwd)
+}
+
+func (w *Watcher) insertCopilotCLIHookEventWithAgent(ts time.Time, fctx *copilotCLIContext, eventType, agentID, agentType string, metadata map[string]string) {
+	w.insertCopilotCLIHookEventFull(ts, fctx, eventType, "", "", "", "", agentID, agentType, metadata, "")
+}
+
+func (w *Watcher) insertCopilotCLIHookEventFull(ts time.Time, fctx *copilotCLIContext, eventType, toolName, toolInput, toolUseID, toolResult, agentID, agentType string, metadata map[string]string, cwd string) {
+	msTs := ts.UnixMilli()
+	for {
+		prev := lastInsertTS.Load()
+		next := msTs
+		if next <= prev {
+			next = prev + 1
+		}
+		if lastInsertTS.CompareAndSwap(prev, next) {
+			msTs = next
+			break
+		}
+	}
+
+	dbSessionID := fctx.dbSessionID()
+
+	metadataJSON := ""
+	if len(metadata) > 0 {
+		if b, err := json.Marshal(metadata); err == nil {
+			metadataJSON = string(b)
+		}
+	}
+
+	if cwd == "" {
+		cwd = fctx.cwd
+	}
+
+	sql := fmt.Sprintf(
+		"INSERT INTO tma1_hook_events "+
+			"(ts, session_id, event_type, agent_source, tool_name, tool_input, tool_result, "+
+			"tool_use_id, agent_id, agent_type, notification_type, \"message\", cwd, transcript_path, conversation_id, metadata) "+
+			"VALUES (%d, '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '', '', '%s', '', '%s', '%s')",
+		msTs,
+		escapeSQLString(dbSessionID),
+		escapeSQLString(eventType),
+		copilotCLIAgentSource,
+		escapeSQLString(truncate(toolName, 256)),
+		escapeSQLString(truncate(toolInput, maxToolInput)),
+		escapeSQLString(truncate(toolResult, maxToolContent)),
+		escapeSQLString(toolUseID),
+		escapeSQLString(agentID),
+		escapeSQLString(agentType),
+		escapeSQLString(truncate(cwd, 512)),
+		escapeSQLString(dbSessionID),
+		escapeSQLString(metadataJSON),
+	)
+	go func() {
+		insertSem <- struct{}{}
+		defer func() { <-insertSem }()
+		w.execSQL(sql)
+	}()
+}

--- a/server/internal/transcript/copilot_cli.go
+++ b/server/internal/transcript/copilot_cli.go
@@ -16,7 +16,6 @@ import (
 const (
 	copilotCLIScanInterval   = 10 * time.Second
 	copilotCLIActiveAge      = 10 * time.Minute
-	copilotCLIFirstScanAge   = 24 * time.Hour // wider window on first scan to catch older sessions
 	copilotCLIAgentSource    = "copilot_cli"
 	copilotCLISessionPfx     = "cp:"
 )
@@ -40,7 +39,7 @@ func (w *Watcher) StartCopilotCLIScanner(ctx context.Context) {
 	baseDir := filepath.Join(homeDir, ".copilot", "session-state")
 	w.logger.Info("copilot-cli session scanner started", "path", baseDir)
 
-	// First scan uses a wider window to pick up older sessions on fresh install/restart.
+	// First scan has no age limit to pick up ALL historical sessions.
 	firstScan := true
 	ticker := time.NewTicker(copilotCLIScanInterval)
 	defer ticker.Stop()
@@ -51,12 +50,12 @@ func (w *Watcher) StartCopilotCLIScanner(ctx context.Context) {
 			return
 		case <-ticker.C:
 			if _, err := os.Stat(baseDir); err == nil {
-				activeAge := copilotCLIActiveAge
 				if firstScan {
-					activeAge = copilotCLIFirstScanAge
+					w.scanCopilotCLISessionsWithAge(baseDir, 0) // 0 = no limit
 					firstScan = false
+				} else {
+					w.scanCopilotCLISessionsWithAge(baseDir, copilotCLIActiveAge)
 				}
-				w.scanCopilotCLISessionsWithAge(baseDir, activeAge)
 			}
 		}
 	}
@@ -71,10 +70,14 @@ func (w *Watcher) scanCopilotCLISessionsWithAge(baseDir string, activeAge time.D
 
 	// Prune stopped watchers to prevent unbounded memory growth.
 	w.mu.Lock()
-	var stoppedCount int
+	var stoppedCount, activeCount int
 	for key, sw := range w.sessions {
-		if sw.stopped && strings.HasPrefix(key, copilotCLISessionPfx) {
-			stoppedCount++
+		if strings.HasPrefix(key, copilotCLISessionPfx) {
+			if sw.stopped {
+				stoppedCount++
+			} else {
+				activeCount++
+			}
 		}
 	}
 	if stoppedCount > 50 {
@@ -86,26 +89,71 @@ func (w *Watcher) scanCopilotCLISessionsWithAge(baseDir string, activeAge time.D
 	}
 	w.mu.Unlock()
 
+	// Limit concurrent watchers to avoid overwhelming GreptimeDB.
+	const maxConcurrentWatchers = 10
+	newWatchers := 0
+
+	// Sort entries by modification time (newest first) so recent sessions are prioritized.
 	entries, err := os.ReadDir(baseDir)
 	if err != nil {
 		return
 	}
+
+	type sessionFile struct {
+		id   string
+		path string
+		mod  time.Time
+	}
+	var candidates []sessionFile
 	for _, entry := range entries {
 		if !entry.IsDir() {
 			continue
 		}
 		eventsFile := filepath.Join(baseDir, entry.Name(), "events.jsonl")
 		info, err := os.Stat(eventsFile)
-		if err != nil || now.Sub(info.ModTime()) > activeAge {
+		if err != nil {
 			continue
 		}
-		sessionID := entry.Name()
-		watcherKey := copilotCLISessionPfx + sessionID
-		w.watchCopilotCLI(watcherKey, sessionID, eventsFile)
+		if activeAge > 0 && now.Sub(info.ModTime()) > activeAge {
+			continue
+		}
+		candidates = append(candidates, sessionFile{entry.Name(), eventsFile, info.ModTime()})
+	}
+
+	// Sort newest first.
+	for i := 0; i < len(candidates); i++ {
+		for j := i + 1; j < len(candidates); j++ {
+			if candidates[j].mod.After(candidates[i].mod) {
+				candidates[i], candidates[j] = candidates[j], candidates[i]
+			}
+		}
+	}
+
+	for _, c := range candidates {
+		watcherKey := copilotCLISessionPfx + c.id
+		w.mu.Lock()
+		existing, ok := w.sessions[watcherKey]
+		alreadyWatching := ok && !existing.stopped
+		w.mu.Unlock()
+
+		if alreadyWatching {
+			continue
+		}
+		if activeCount+newWatchers >= maxConcurrentWatchers {
+			break // defer remaining to next scan cycle
+		}
+		// Old completed sessions stop immediately after backfill (no idle wait).
+		isActive := now.Sub(c.mod) < copilotCLIActiveAge
+		w.watchCopilotCLIWithActive(watcherKey, c.id, c.path, isActive)
+		newWatchers++
 	}
 }
 
 func (w *Watcher) watchCopilotCLI(watcherKey, sessionID, filePath string) {
+	w.watchCopilotCLIWithActive(watcherKey, sessionID, filePath, true)
+}
+
+func (w *Watcher) watchCopilotCLIWithActive(watcherKey, sessionID, filePath string, isActive bool) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 
@@ -125,11 +173,11 @@ func (w *Watcher) watchCopilotCLI(watcherKey, sessionID, filePath string) {
 	sw := &sessionWatch{cancel: cancel, seen: seen}
 	w.sessions[watcherKey] = sw
 
-	go w.tailCopilotCLIFile(ctx, watcherKey, sessionID, filePath, seen)
+	go w.tailCopilotCLIFile(ctx, watcherKey, sessionID, filePath, seen, isActive)
 	w.logger.Info("watching copilot-cli session", "session", sessionID, "file", filePath)
 }
 
-func (w *Watcher) tailCopilotCLIFile(ctx context.Context, watcherKey, sessionID, filePath string, seen map[string]struct{}) {
+func (w *Watcher) tailCopilotCLIFile(ctx context.Context, watcherKey, sessionID, filePath string, seen map[string]struct{}, isActive bool) {
 	defer func() {
 		w.mu.Lock()
 		if sw, ok := w.sessions[watcherKey]; ok {
@@ -158,38 +206,14 @@ func (w *Watcher) tailCopilotCLIFile(ctx context.Context, watcherKey, sessionID,
 
 	fctx := &copilotCLIContext{sessionID: sessionID}
 
-	// Skip backfill if this session was already ingested (prevents duplicates on restart).
-	// But always read the first line to populate context (model, cwd).
-	dbSID := copilotCLISessionPfx + sessionID
-	skipBackfill := w.copilotCLISessionExists(dbSID)
-	if skipBackfill {
-		// Read first line to extract session context (cwd, model), then seek to end.
-		firstReader := bufio.NewReader(f)
-		if firstLine, err := firstReader.ReadString('\n'); err == nil {
-			trimmed := strings.TrimSpace(firstLine)
-			if trimmed != "" {
-				var ev copilotCLIEvent
-				if json.Unmarshal([]byte(trimmed), &ev) == nil && ev.Type == "session.start" {
-					var data struct {
-						Context struct {
-							CWD string `json:"cwd"`
-						} `json:"context"`
-					}
-					if json.Unmarshal(ev.Data, &data) == nil {
-						fctx.cwd = data.Context.CWD
-					}
-				}
-			}
-		}
-		if _, err := f.Seek(0, io.SeekEnd); err != nil {
-			w.logger.Warn("copilot-cli seek to end failed", "session", sessionID, "error", err)
-		}
-	}
-
 	reader := bufio.NewReader(f)
 	var buf strings.Builder
 	idleCount := 0
-	const maxIdlePolls = 600 // 5 minutes at 500ms
+	// Active sessions wait 5 minutes for new data; completed sessions stop immediately.
+	maxIdlePolls := 600 // 5 minutes at 500ms
+	if !isActive {
+		maxIdlePolls = 2 // 1 second — just drain any buffered writes
+	}
 
 	for {
 		line, err := reader.ReadString('\n')

--- a/server/internal/transcript/copilot_cli.go
+++ b/server/internal/transcript/copilot_cli.go
@@ -14,19 +14,18 @@ import (
 )
 
 const (
-	copilotCLIScanInterval = 10 * time.Second
-	copilotCLIActiveAge    = 10 * time.Minute
-	copilotCLIAgentSource  = "copilot_cli"
-	copilotCLISessionPfx   = "cp:"
+	copilotCLIScanInterval   = 10 * time.Second
+	copilotCLIActiveAge      = 10 * time.Minute
+	copilotCLIFirstScanAge   = 24 * time.Hour // wider window on first scan to catch older sessions
+	copilotCLIAgentSource    = "copilot_cli"
+	copilotCLISessionPfx     = "cp:"
 )
 
-// escapeSQLStringFull escapes both single quotes and backslashes for SQL string literals.
-// GreptimeDB interprets backslash as an escape character in string literals,
-// so Windows paths like C:\Users must be escaped as C:\\Users.
+// escapeSQLStringFull escapes single quotes for SQL string literals.
+// GreptimeDB's /v1/sql API does NOT interpret backslash escapes,
+// so only single quotes need escaping.
 func escapeSQLStringFull(s string) string {
-	s = strings.ReplaceAll(s, "\\", "\\\\")
-	s = strings.ReplaceAll(s, "'", "''")
-	return s
+	return strings.ReplaceAll(s, "'", "''")
 }
 
 // StartCopilotCLIScanner periodically scans ~/.copilot/session-state/ for active
@@ -41,6 +40,8 @@ func (w *Watcher) StartCopilotCLIScanner(ctx context.Context) {
 	baseDir := filepath.Join(homeDir, ".copilot", "session-state")
 	w.logger.Info("copilot-cli session scanner started", "path", baseDir)
 
+	// First scan uses a wider window to pick up older sessions on fresh install/restart.
+	firstScan := true
 	ticker := time.NewTicker(copilotCLIScanInterval)
 	defer ticker.Stop()
 
@@ -50,13 +51,22 @@ func (w *Watcher) StartCopilotCLIScanner(ctx context.Context) {
 			return
 		case <-ticker.C:
 			if _, err := os.Stat(baseDir); err == nil {
-				w.scanCopilotCLISessions(baseDir)
+				activeAge := copilotCLIActiveAge
+				if firstScan {
+					activeAge = copilotCLIFirstScanAge
+					firstScan = false
+				}
+				w.scanCopilotCLISessionsWithAge(baseDir, activeAge)
 			}
 		}
 	}
 }
 
 func (w *Watcher) scanCopilotCLISessions(baseDir string) {
+	w.scanCopilotCLISessionsWithAge(baseDir, copilotCLIActiveAge)
+}
+
+func (w *Watcher) scanCopilotCLISessionsWithAge(baseDir string, activeAge time.Duration) {
 	now := time.Now()
 
 	// Prune stopped watchers to prevent unbounded memory growth.
@@ -86,7 +96,7 @@ func (w *Watcher) scanCopilotCLISessions(baseDir string) {
 		}
 		eventsFile := filepath.Join(baseDir, entry.Name(), "events.jsonl")
 		info, err := os.Stat(eventsFile)
-		if err != nil || now.Sub(info.ModTime()) > copilotCLIActiveAge {
+		if err != nil || now.Sub(info.ModTime()) > activeAge {
 			continue
 		}
 		sessionID := entry.Name()
@@ -654,7 +664,7 @@ func (w *Watcher) insertCopilotCLIHookEventFull(ts time.Time, fctx *copilotCLICo
 		escapeSQLString(agentType),
 		escapeSQLStringFull(truncate(cwd, 512)),
 		escapeSQLString(dbSessionID),
-		escapeSQLStringFull(metadataJSON),
+		escapeSQLString(metadataJSON), // json.Marshal already escapes backslashes
 	)
 	go func() {
 		insertSem <- struct{}{}

--- a/server/internal/transcript/copilot_cli.go
+++ b/server/internal/transcript/copilot_cli.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -135,6 +136,15 @@ func (w *Watcher) tailCopilotCLIFile(ctx context.Context, watcherKey, sessionID,
 		return
 	}
 	defer f.Close()
+
+	// Skip backfill if this session was already ingested (prevents duplicates on restart).
+	dbSID := copilotCLISessionPfx + sessionID
+	if w.copilotCLISessionExists(dbSID) {
+		// Seek to end — only process new lines written after this point.
+		if _, err := f.Seek(0, io.SeekEnd); err != nil {
+			w.logger.Warn("copilot-cli seek to end failed", "session", sessionID, "error", err)
+		}
+	}
 
 	reader := bufio.NewReader(f)
 	var buf strings.Builder
@@ -449,6 +459,32 @@ func (w *Watcher) handleCopilotCLISkillInvoked(ts time.Time, ev copilotCLIEvent,
 	}
 	metadata := map[string]string{"skill": data.Skill}
 	w.insertCopilotCLIHookEvent(ts, fctx, "SkillInvoked", "", "", "", "", metadata)
+}
+
+// copilotCLISessionExists checks if data for this session already exists in GreptimeDB.
+// Used to skip backfill on restart and prevent duplicate ingestion.
+func (w *Watcher) copilotCLISessionExists(dbSessionID string) bool {
+	form := url.Values{}
+	form.Set("sql", fmt.Sprintf(
+		"SELECT 1 FROM tma1_hook_events WHERE session_id = '%s' AND agent_source = 'copilot_cli' LIMIT 1",
+		escapeSQLString(dbSessionID),
+	))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	req, err := newPostRequest(ctx, w.sqlURL, form)
+	if err != nil {
+		return false
+	}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	// If the response contains any row data, the session exists.
+	return resp.StatusCode == 200 && strings.Contains(string(body), "\"rows\":[")
 }
 
 // insertCopilotCLIMessage inserts a conversation message into tma1_messages.

--- a/server/internal/transcript/copilot_cli_test.go
+++ b/server/internal/transcript/copilot_cli_test.go
@@ -1,0 +1,292 @@
+package transcript
+
+import (
+	"io"
+	"log/slog"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestProcessCopilotCLILineSessionStart(t *testing.T) {
+	sqlCh := make(chan string, 4)
+	ts := httptest.NewServer(httpTestHandler(sqlCh))
+	defer ts.Close()
+
+	oldClient := httpClient
+	httpClient = ts.Client()
+	defer func() { httpClient = oldClient }()
+
+	w := &Watcher{
+		sqlURL: ts.URL,
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	seen := make(map[string]struct{})
+	fctx := &copilotCLIContext{sessionID: "abc-123"}
+
+	w.processCopilotCLILine("abc-123",
+		`{"type":"session.start","data":{"sessionId":"abc-123","copilotVersion":"1.0.28","context":{"cwd":"/tmp/project","gitRoot":"/tmp/project","branch":"main","headCommit":"deadbeef","repository":"owner/repo"}},"id":"evt-1","timestamp":"2026-04-16T01:00:00Z","parentId":null}`,
+		seen, fctx)
+
+	sql := waitForSQL(t, sqlCh)
+	if !strings.Contains(sql, "SessionStart") {
+		t.Fatalf("expected SessionStart event, got: %s", sql)
+	}
+	if !strings.Contains(sql, "copilot_cli") {
+		t.Fatalf("expected agent_source copilot_cli, got: %s", sql)
+	}
+	if !strings.Contains(sql, "cp:abc-123") {
+		t.Fatalf("expected namespaced session ID cp:abc-123, got: %s", sql)
+	}
+	if !strings.Contains(sql, "main") {
+		t.Fatalf("expected branch info in metadata, got: %s", sql)
+	}
+}
+
+func TestProcessCopilotCLILineUserMessage(t *testing.T) {
+	sqlCh := make(chan string, 4)
+	ts := httptest.NewServer(httpTestHandler(sqlCh))
+	defer ts.Close()
+
+	oldClient := httpClient
+	httpClient = ts.Client()
+	defer func() { httpClient = oldClient }()
+
+	w := &Watcher{
+		sqlURL: ts.URL,
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	seen := make(map[string]struct{})
+	fctx := &copilotCLIContext{sessionID: "abc-123", model: "claude-opus-4.6"}
+
+	w.processCopilotCLILine("abc-123",
+		`{"type":"user.message","data":{"content":"fix the bug","transformedContent":"fix the bug"},"id":"evt-2","timestamp":"2026-04-16T01:01:00Z","parentId":"evt-1"}`,
+		seen, fctx)
+
+	sql := waitForSQL(t, sqlCh)
+	if !strings.Contains(sql, "tma1_messages") {
+		t.Fatalf("expected insert into tma1_messages, got: %s", sql)
+	}
+	if !strings.Contains(sql, "fix the bug") {
+		t.Fatalf("expected user content, got: %s", sql)
+	}
+	if !strings.Contains(sql, "user") {
+		t.Fatalf("expected role=user, got: %s", sql)
+	}
+}
+
+func TestProcessCopilotCLILineAssistantWithReasoning(t *testing.T) {
+	sqlCh := make(chan string, 4)
+	ts := httptest.NewServer(httpTestHandler(sqlCh))
+	defer ts.Close()
+
+	oldClient := httpClient
+	httpClient = ts.Client()
+	defer func() { httpClient = oldClient }()
+
+	w := &Watcher{
+		sqlURL: ts.URL,
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	seen := make(map[string]struct{})
+	fctx := &copilotCLIContext{sessionID: "abc-123", model: "claude-opus-4.6"}
+
+	w.processCopilotCLILine("abc-123",
+		`{"type":"assistant.message","data":{"content":"Here is the fix","reasoningText":"Let me analyze the code","outputTokens":150},"id":"evt-3","timestamp":"2026-04-16T01:02:00Z","parentId":"evt-2"}`,
+		seen, fctx)
+
+	// Should produce two messages: thinking + assistant.
+	sql1 := waitForSQL(t, sqlCh)
+	sql2 := waitForSQL(t, sqlCh)
+	sqls := []string{sql1, sql2}
+
+	var hasThinking, hasAssistant bool
+	for _, sql := range sqls {
+		if strings.Contains(sql, "thinking") && strings.Contains(sql, "Let me analyze") {
+			hasThinking = true
+		}
+		if strings.Contains(sql, "'assistant'") && strings.Contains(sql, "Here is the fix") {
+			hasAssistant = true
+		}
+	}
+	if !hasThinking {
+		t.Fatalf("expected thinking message with reasoning text, got: %v", sqls)
+	}
+	if !hasAssistant {
+		t.Fatalf("expected assistant message with content, got: %v", sqls)
+	}
+}
+
+func TestProcessCopilotCLILineToolSuccess(t *testing.T) {
+	sqlCh := make(chan string, 4)
+	ts := httptest.NewServer(httpTestHandler(sqlCh))
+	defer ts.Close()
+
+	oldClient := httpClient
+	httpClient = ts.Client()
+	defer func() { httpClient = oldClient }()
+
+	w := &Watcher{
+		sqlURL: ts.URL,
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	seen := make(map[string]struct{})
+	fctx := &copilotCLIContext{sessionID: "abc-123", model: "claude-opus-4.6"}
+
+	w.processCopilotCLILine("abc-123",
+		`{"type":"tool.execution_complete","data":{"toolCallId":"tool-1","model":"claude-opus-4.6","success":true,"result":{"content":"output text"}},"id":"evt-4","timestamp":"2026-04-16T01:03:00Z","parentId":"evt-3"}`,
+		seen, fctx)
+
+	sql := waitForSQL(t, sqlCh)
+	if !strings.Contains(sql, "PostToolUse") {
+		t.Fatalf("expected PostToolUse for success=true, got: %s", sql)
+	}
+}
+
+func TestProcessCopilotCLILineToolFailure(t *testing.T) {
+	sqlCh := make(chan string, 4)
+	ts := httptest.NewServer(httpTestHandler(sqlCh))
+	defer ts.Close()
+
+	oldClient := httpClient
+	httpClient = ts.Client()
+	defer func() { httpClient = oldClient }()
+
+	w := &Watcher{
+		sqlURL: ts.URL,
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	seen := make(map[string]struct{})
+	fctx := &copilotCLIContext{sessionID: "abc-123"}
+
+	w.processCopilotCLILine("abc-123",
+		`{"type":"tool.execution_complete","data":{"toolCallId":"tool-2","model":"claude-opus-4.6","success":false,"result":{"content":"error: permission denied"}},"id":"evt-5","timestamp":"2026-04-16T01:04:00Z","parentId":"evt-3"}`,
+		seen, fctx)
+
+	sql := waitForSQL(t, sqlCh)
+	if !strings.Contains(sql, "PostToolUseFailure") {
+		t.Fatalf("expected PostToolUseFailure for success=false, got: %s", sql)
+	}
+}
+
+func TestProcessCopilotCLILineModelPropagation(t *testing.T) {
+	sqlCh := make(chan string, 8)
+	ts := httptest.NewServer(httpTestHandler(sqlCh))
+	defer ts.Close()
+
+	oldClient := httpClient
+	httpClient = ts.Client()
+	defer func() { httpClient = oldClient }()
+
+	w := &Watcher{
+		sqlURL: ts.URL,
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	seen := make(map[string]struct{})
+	fctx := &copilotCLIContext{sessionID: "abc-123"}
+
+	// Model change sets model on context.
+	w.processCopilotCLILine("abc-123",
+		`{"type":"session.model_change","data":{"newModel":"gpt-5.4"},"id":"evt-m1","timestamp":"2026-04-16T01:05:00Z","parentId":null}`,
+		seen, fctx)
+
+	// Drain the synthetic model message.
+	waitForSQL(t, sqlCh)
+
+	if fctx.model != "gpt-5.4" {
+		t.Fatalf("expected model to be gpt-5.4, got %s", fctx.model)
+	}
+
+	// Now an assistant message should carry the model.
+	w.processCopilotCLILine("abc-123",
+		`{"type":"assistant.message","data":{"content":"done","outputTokens":10},"id":"evt-a1","timestamp":"2026-04-16T01:06:00Z","parentId":null}`,
+		seen, fctx)
+
+	sql := waitForSQL(t, sqlCh)
+	if !strings.Contains(sql, "gpt-5.4") {
+		t.Fatalf("expected model gpt-5.4 on assistant message, got: %s", sql)
+	}
+}
+
+func TestProcessCopilotCLILineSubagentLifecycle(t *testing.T) {
+	sqlCh := make(chan string, 4)
+	ts := httptest.NewServer(httpTestHandler(sqlCh))
+	defer ts.Close()
+
+	oldClient := httpClient
+	httpClient = ts.Client()
+	defer func() { httpClient = oldClient }()
+
+	w := &Watcher{
+		sqlURL: ts.URL,
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	seen := make(map[string]struct{})
+	fctx := &copilotCLIContext{sessionID: "abc-123"}
+
+	w.processCopilotCLILine("abc-123",
+		`{"type":"subagent.started","data":{"toolCallId":"sa-1","agentName":"rubber-duck","agentDescription":"A critic agent"},"id":"evt-sa1","timestamp":"2026-04-16T01:07:00Z","parentId":null}`,
+		seen, fctx)
+
+	sql := waitForSQL(t, sqlCh)
+	if !strings.Contains(sql, "SubagentStart") {
+		t.Fatalf("expected SubagentStart, got: %s", sql)
+	}
+	if !strings.Contains(sql, "rubber-duck") {
+		t.Fatalf("expected agent_type rubber-duck, got: %s", sql)
+	}
+
+	w.processCopilotCLILine("abc-123",
+		`{"type":"subagent.completed","data":{"toolCallId":"sa-1","agentName":"rubber-duck","model":"gpt-5.4","totalToolCalls":36,"totalTokens":898928,"durationMs":259183},"id":"evt-sa2","timestamp":"2026-04-16T01:11:00Z","parentId":null}`,
+		seen, fctx)
+
+	sql = waitForSQL(t, sqlCh)
+	if !strings.Contains(sql, "SubagentStop") {
+		t.Fatalf("expected SubagentStop, got: %s", sql)
+	}
+	if !strings.Contains(sql, "898928") {
+		t.Fatalf("expected total_tokens in metadata, got: %s", sql)
+	}
+}
+
+func TestProcessCopilotCLILineDedup(t *testing.T) {
+	sqlCh := make(chan string, 4)
+	ts := httptest.NewServer(httpTestHandler(sqlCh))
+	defer ts.Close()
+
+	oldClient := httpClient
+	httpClient = ts.Client()
+	defer func() { httpClient = oldClient }()
+
+	w := &Watcher{
+		sqlURL: ts.URL,
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	seen := make(map[string]struct{})
+	fctx := &copilotCLIContext{sessionID: "abc-123"}
+
+	line := `{"type":"user.message","data":{"content":"hello"},"id":"evt-dup","timestamp":"2026-04-16T01:00:00Z","parentId":null}`
+
+	// First call should insert.
+	w.processCopilotCLILine("abc-123", line, seen, fctx)
+	waitForSQL(t, sqlCh)
+
+	// Second call with same event ID should be deduped (no SQL).
+	w.processCopilotCLILine("abc-123", line, seen, fctx)
+
+	// Verify no second SQL was produced.
+	select {
+	case sql := <-sqlCh:
+		t.Fatalf("expected dedup to prevent second insert, but got: %s", sql)
+	default:
+		// OK — no second insert.
+	}
+}
+
+func TestCopilotCLIContextDBSessionID(t *testing.T) {
+	fctx := &copilotCLIContext{sessionID: "abc-123-def"}
+	want := "cp:abc-123-def"
+	if got := fctx.dbSessionID(); got != want {
+		t.Fatalf("dbSessionID() = %q, want %q", got, want)
+	}
+}

--- a/server/web/css/style.css
+++ b/server/web/css/style.css
@@ -717,6 +717,7 @@ tr.active-trace td { background: var(--bg-hover); }
 .badge-cc { background: rgba(121,192,255,0.15); color: var(--blue); padding: 2px 8px; border-radius: 4px; font-size: 11px; font-weight: 600; }
 .badge-codex { background: rgba(210,153,255,0.15); color: var(--purple); padding: 2px 8px; border-radius: 4px; font-size: 11px; font-weight: 600; }
 .badge-oc { background: rgba(255,140,105,0.15); color: #ff8c69; padding: 2px 8px; border-radius: 4px; font-size: 11px; font-weight: 600; }
+.badge-copilot { background: rgba(87,203,142,0.15); color: var(--green); padding: 2px 8px; border-radius: 4px; font-size: 11px; font-weight: 600; }
 .sess-row { cursor: pointer; }
 .sess-row:hover { background: rgba(255,255,255,0.04); }
 .search-result-item { padding: 12px; border-bottom: 1px solid var(--border); cursor: pointer; }

--- a/server/web/index.html
+++ b/server/web/index.html
@@ -1141,8 +1141,9 @@
           <option value="claude_code" data-i18n="sessions.source_cc">Claude Code</option>
           <option value="codex" data-i18n="sessions.source_codex">Codex</option>
           <option value="openclaw" data-i18n="sessions.source_openclaw">OpenClaw</option>
+          <option value="copilot_cli" data-i18n="sessions.source_copilot_cli">Copilot CLI</option>
         </select>
-        <input class="filter-input" id="sess-keyword-filter" type="text"
+        <input class="filter-input" id="sess-keyword-filter"type="text"
                placeholder="Filter by tool or keyword..."
                data-i18n-placeholder="sessions.filter_keyword"
                oninput="sess_debouncedFilter()" style="max-width:240px" />
@@ -1212,6 +1213,7 @@
         <option value="claude_code" data-i18n="sessions.source_cc">Claude Code</option>
         <option value="codex" data-i18n="sessions.source_codex">Codex</option>
         <option value="openclaw" data-i18n="sessions.source_openclaw">OpenClaw</option>
+        <option value="copilot_cli" data-i18n="sessions.source_copilot_cli">Copilot CLI</option>
       </select>
     </div>
 

--- a/server/web/index.html
+++ b/server/web/index.html
@@ -1108,6 +1108,89 @@
   </div>
   </div><!-- /view-traces -->
 
+  <!-- ========================= COPILOT CLI VIEW ========================= -->
+  <div id="view-copilot-cli" style="display:none">
+    <div class="cards">
+      <div class="card">
+        <div class="label">Est. Cost</div>
+        <div class="value cost" id="gcp-val-cost">&mdash;</div>
+      </div>
+      <div class="card">
+        <div class="label">Output Tokens</div>
+        <div class="value tokens" id="gcp-val-tokens">&mdash;</div>
+      </div>
+      <div class="card">
+        <div class="label">Tool Calls</div>
+        <div class="value requests" id="gcp-val-tools">&mdash;</div>
+      </div>
+      <div class="card">
+        <div class="label">Sessions</div>
+        <div class="value" id="gcp-val-sessions">&mdash;</div>
+      </div>
+      <div class="card">
+        <div class="label">Avg Duration</div>
+        <div class="value latency" id="gcp-val-duration">&mdash;</div>
+      </div>
+    </div>
+
+    <div class="tabs" id="gcp-tabs">
+      <button class="tab active" data-gcptab="gcp-overview">Overview</button>
+      <button class="tab" data-gcptab="gcp-tools">Tools</button>
+      <button class="tab" data-gcptab="gcp-cost">Cost</button>
+      <button class="tab" data-link="sessions" onclick="switchToSessions('copilot_cli')">Sessions</button>
+    </div>
+
+    <!-- Overview -->
+    <div class="tab-content active" id="tab-gcp-overview">
+      <div class="chart-container">
+        <h3>Token Usage Over Time</h3>
+        <div id="gcp-chart-tokens"><div class="chart-empty">Waiting for data...</div></div>
+      </div>
+      <div class="chart-container">
+        <h3>Cost Over Time</h3>
+        <div id="gcp-chart-cost"><div class="chart-empty">Waiting for data...</div></div>
+      </div>
+      <div class="chart-container">
+        <h3>Tool Distribution</h3>
+        <div id="gcp-tool-dist" class="bar-chart"><div class="chart-empty">Waiting for data...</div></div>
+      </div>
+      <div class="chart-container">
+        <h3>Activity Heatmap</h3>
+        <div id="gcp-activity-heatmap"><div class="chart-empty">Waiting for data...</div></div>
+      </div>
+    </div>
+
+    <!-- Tools -->
+    <div class="tab-content" id="tab-gcp-tools">
+      <div class="chart-container">
+        <h3>Tool Performance</h3>
+        <div style="overflow-x:auto">
+          <table>
+            <thead><tr>
+              <th>Tool</th><th>Calls</th><th>Failures</th><th>Failure Rate</th>
+            </tr></thead>
+            <tbody id="gcp-tools-body"><tr><td colspan="4" class="loading">Loading...</td></tr></tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+
+    <!-- Cost -->
+    <div class="tab-content" id="tab-gcp-cost">
+      <div class="chart-container">
+        <h3>Cost by Model</h3>
+        <div style="overflow-x:auto">
+          <table>
+            <thead><tr>
+              <th>Model</th><th>Output Tokens</th><th>Messages</th><th>Est. Cost</th>
+            </tr></thead>
+            <tbody id="gcp-cost-body"><tr><td colspan="4" class="loading">Loading...</td></tr></tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+
   <!-- ========================= SESSIONS VIEW ========================= -->
   <div id="view-sessions" style="display:none">
     <div class="cards">
@@ -1403,6 +1486,7 @@
   <script src="/js/traces.js"></script>
   <script src="/js/claude-code.js"></script>
   <script src="/js/codex.js"></script>
+  <script src="/js/copilot-cli.js"></script>
   <script src="/js/openclaw.js"></script>
   <script src="/js/sessions-stats.js"></script>
   <script src="/js/sessions-timeline.js"></script>

--- a/server/web/js/agent-canvas.js
+++ b/server/web/js/agent-canvas.js
@@ -692,14 +692,33 @@ var AgentCanvas = (function () {
 
   function scheduleNext() {
     if (replayIdx >= replayEvents.length || replayPaused) return;
-    var ev = replayEvents[replayIdx];
-    processEvent(ev);
-    replayCurrentTs = ev.ts;
-    replayIdx++;
-    if (replayIdx < replayEvents.length) {
-      var delay = (replayEvents[replayIdx].ts - ev.ts) / replaySpeed;
-      delay = Math.max(16, Math.min(delay, 2000));
-      replayTimer = setTimeout(scheduleNext, delay);
+    // Batch-process events that are close together (< 200ms apart) in one frame
+    // to avoid hundreds of tiny setTimeout calls for rapid-fire tool events.
+    while (replayIdx < replayEvents.length) {
+      var ev = replayEvents[replayIdx];
+      var prevTs = replayCurrentTs;
+      processEvent(ev);
+      replayCurrentTs = ev.ts;
+      replayIdx++;
+      // Advance running tool ages by the replay time gap.
+      var replayGapSec = (replayCurrentTs - prevTs) / 1000;
+      if (replayGapSec > 1) {
+        for (var tid in toolCalls) {
+          if (toolCalls[tid].state === 'running') {
+            toolCalls[tid].age = (toolCalls[tid].age || 0) + replayGapSec;
+          }
+        }
+      }
+      // If next event is within 200ms, process it immediately (same frame).
+      if (replayIdx < replayEvents.length) {
+        var nextGap = replayEvents[replayIdx].ts - ev.ts;
+        if (nextGap < 200) continue; // batch into same frame
+        // Cap delay: max 500ms real-time to keep replay moving during idle gaps.
+        var delay = nextGap / replaySpeed;
+        delay = Math.max(16, Math.min(delay, 500));
+        replayTimer = setTimeout(scheduleNext, delay);
+        return;
+      }
     }
   }
 

--- a/server/web/js/copilot-cli.js
+++ b/server/web/js/copilot-cli.js
@@ -31,10 +31,10 @@ async function gcp_loadCards() {
         "SUM(CASE WHEN message_type IN ('user','tool_result','tool_use') THEN LENGTH(COALESCE(content,''))/4 ELSE 0 END) AS est_in_tok " +
         gcp_msgWhere() + " AND model != '' GROUP BY model"
       ),
-      // Avg duration
+      // Avg duration (cast to epoch ms to avoid Duration arithmetic)
       query(
         "SELECT AVG(dur_sec) AS v FROM (" +
-        "SELECT (MAX(ts) - MIN(ts)) / 1000 AS dur_sec " +
+        "SELECT (MAX(CAST(ts AS BIGINT)) - MIN(CAST(ts AS BIGINT))) / 1000 AS dur_sec " +
         gcp_hookWhere() + " GROUP BY session_id HAVING COUNT(*) > 1) sub"
       ),
     ]);

--- a/server/web/js/copilot-cli.js
+++ b/server/web/js/copilot-cli.js
@@ -1,0 +1,241 @@
+// copilot-cli.js — Copilot CLI view: gcp_* functions
+// Data comes from tma1_hook_events (agent_source='copilot_cli') and tma1_messages (session_id LIKE 'cp:%')
+// Depends on: core.js, chart.js
+
+function gcp_hookWhere() {
+  return "FROM tma1_hook_events " +
+    "WHERE ts > NOW() - INTERVAL '" + intervalSQL() + "' " +
+    "AND agent_source = 'copilot_cli'";
+}
+
+function gcp_msgWhere() {
+  return "FROM tma1_messages " +
+    "WHERE ts > NOW() - INTERVAL '" + intervalSQL() + "' " +
+    "AND session_id LIKE 'cp:%'";
+}
+
+async function gcp_loadCards() {
+  await loadPricing();
+  try {
+    var results = await Promise.all([
+      // Output tokens
+      query("SELECT SUM(COALESCE(output_tokens, 0)) AS v " + gcp_msgWhere()),
+      // Tool calls
+      query("SELECT COUNT(*) AS v " + gcp_hookWhere() + " AND event_type = 'PreToolUse'"),
+      // Sessions
+      query("SELECT COUNT(DISTINCT session_id) AS v " + gcp_hookWhere()),
+      // Cost estimate from messages
+      query(
+        "SELECT model, " +
+        "SUM(COALESCE(output_tokens, 0)) AS out_tok, " +
+        "SUM(CASE WHEN message_type IN ('user','tool_result','tool_use') THEN LENGTH(COALESCE(content,''))/4 ELSE 0 END) AS est_in_tok " +
+        gcp_msgWhere() + " AND model != '' GROUP BY model"
+      ),
+      // Avg duration
+      query(
+        "SELECT AVG(dur_sec) AS v FROM (" +
+        "SELECT (MAX(ts) - MIN(ts)) / 1000 AS dur_sec " +
+        gcp_hookWhere() + " GROUP BY session_id HAVING COUNT(*) > 1) sub"
+      ),
+    ]);
+
+    var outTok = Number(rows(results[0])?.[0]?.[0]) || 0;
+    var toolCalls = Number(rows(results[1])?.[0]?.[0]) || 0;
+    var sessions = Number(rows(results[2])?.[0]?.[0]) || 0;
+    var avgDur = Number(rows(results[4])?.[0]?.[0]) || 0;
+
+    // Calculate cost from model pricing
+    var totalCost = 0;
+    var costRows = rowsToObjects(results[3]);
+    for (var i = 0; i < costRows.length; i++) {
+      var cr = costRows[i];
+      var price = sess_lookupPrice(cr.model);
+      var estIn = Number(cr.est_in_tok) || 0;
+      var out = Number(cr.out_tok) || 0;
+      totalCost += estIn * price.input / 1000000 + out * price.output / 1000000;
+    }
+
+    document.getElementById('gcp-val-cost').textContent = fmtCost(totalCost);
+    document.getElementById('gcp-val-tokens').textContent = fmtNum(outTok);
+    document.getElementById('gcp-val-tools').textContent = fmtNum(toolCalls);
+    document.getElementById('gcp-val-sessions').textContent = fmtNum(sessions);
+    document.getElementById('gcp-val-duration').textContent = fmtDurSec(avgDur);
+
+    return sessions > 0;
+  } catch (err) {
+    var banner = document.getElementById('error-banner');
+    if (banner) { banner.style.display = 'block'; banner.textContent = 'Copilot CLI: ' + err.message; }
+    return false;
+  }
+}
+
+async function gcp_loadOverview() {
+  await Promise.all([
+    gcp_loadTokenChart(),
+    gcp_loadCostChart(),
+    gcp_loadToolDist(),
+    gcp_loadActivityHeatmap(),
+  ]);
+}
+
+async function gcp_loadTokenChart() {
+  var el = document.getElementById('gcp-chart-tokens');
+  if (!el) return;
+  try {
+    var res = await query(
+      "SELECT date_bin('" + chartBucket() + "'::INTERVAL, ts) AS t, " +
+      "SUM(COALESCE(output_tokens, 0)) AS output_tok, " +
+      "SUM(CASE WHEN message_type IN ('user','tool_result','tool_use') THEN LENGTH(COALESCE(content,''))/4 ELSE 0 END) AS est_input_tok " +
+      gcp_msgWhere() + " GROUP BY t ORDER BY t"
+    );
+    var data = rowsToObjects(res);
+    if (!data.length) { el.innerHTML = '<div class="chart-empty">No token data yet</div>'; return; }
+    renderChart('gcp-chart-tokens', data, [
+      { label: 'Est. Input Tokens', key: 'est_input_tok', color: '#79c0ff' },
+      { label: 'Output Tokens', key: 'output_tok', color: '#f0883e' },
+    ], function(v) { return fmtNum(v); });
+  } catch { el.innerHTML = '<div class="chart-empty">Failed to load token data</div>'; }
+}
+
+async function gcp_loadCostChart() {
+  var el = document.getElementById('gcp-chart-cost');
+  if (!el) return;
+  await loadPricing();
+  try {
+    var res = await query(
+      "SELECT date_bin('" + chartBucket() + "'::INTERVAL, ts) AS t, " +
+      "model, " +
+      "SUM(COALESCE(output_tokens, 0)) AS out_tok, " +
+      "SUM(CASE WHEN message_type IN ('user','tool_result','tool_use') THEN LENGTH(COALESCE(content,''))/4 ELSE 0 END) AS est_in_tok " +
+      gcp_msgWhere() + " AND model != '' GROUP BY t, model ORDER BY t"
+    );
+    var rawData = rowsToObjects(res);
+    if (!rawData.length) { el.innerHTML = '<div class="chart-empty">No cost data yet</div>'; return; }
+
+    // Aggregate cost per time bucket
+    var buckets = {};
+    for (var i = 0; i < rawData.length; i++) {
+      var d = rawData[i];
+      var key = String(d.t);
+      if (!buckets[key]) buckets[key] = { t: d.t, cost: 0 };
+      var price = sess_lookupPrice(d.model);
+      buckets[key].cost += (Number(d.est_in_tok) || 0) * price.input / 1000000 +
+                           (Number(d.out_tok) || 0) * price.output / 1000000;
+    }
+    var data = Object.values(buckets).sort(function(a, b) { return String(a.t) < String(b.t) ? -1 : 1; });
+    renderChart('gcp-chart-cost', data, [
+      { label: 'Cost (USD)', key: 'cost', color: '#f0883e' },
+    ], function(v) { return '$' + Number(v).toFixed(4); });
+  } catch { el.innerHTML = '<div class="chart-empty">Failed to load cost data</div>'; }
+}
+
+async function gcp_loadToolDist() {
+  var el = document.getElementById('gcp-tool-dist');
+  if (!el) return;
+  try {
+    var tc = getThemeColors();
+    var res = await query(
+      "SELECT tool_name, COUNT(*) AS cnt " +
+      gcp_hookWhere() + " AND event_type = 'PreToolUse' AND tool_name != '' " +
+      "GROUP BY tool_name ORDER BY cnt DESC LIMIT 15"
+    );
+    var data = rowsToObjects(res);
+    if (!data.length) { el.innerHTML = '<div class="chart-empty">No tool data yet</div>'; return; }
+    var maxCnt = Math.max.apply(null, data.map(function(d) { return Number(d.cnt) || 0; }));
+    el.innerHTML = data.map(function(d) {
+      var cnt = Number(d.cnt) || 0;
+      var pct = maxCnt > 0 ? (cnt / maxCnt * 100) : 0;
+      return '<div class="bar-row">' +
+        '<div class="bar-label" title="' + escapeHTML(d.tool_name) + '">' + escapeHTML(d.tool_name) + '</div>' +
+        '<div class="bar-track"><div class="bar-fill" style="width:' + pct + '%;background:' + tc.blue + '"></div></div>' +
+        '<div class="bar-value">' + fmtNum(cnt) + '</div></div>';
+    }).join('');
+  } catch { el.innerHTML = '<div class="chart-empty">Failed to load tool data</div>'; }
+}
+
+async function gcp_loadActivityHeatmap() {
+  var el = document.getElementById('gcp-activity-heatmap');
+  if (!el) return;
+  var cfg = heatmapConfig();
+  try {
+    var res = await query(
+      "SELECT date_bin('" + cfg.bucket + "'::INTERVAL, ts) AS t, COUNT(*) AS cnt " +
+      "FROM tma1_hook_events WHERE agent_source = 'copilot_cli' " +
+      "AND ts > NOW() - INTERVAL '" + cfg.interval + "' " +
+      "GROUP BY t ORDER BY t"
+    );
+    renderHeatmap('gcp-activity-heatmap', rowsToObjects(res));
+  } catch { el.innerHTML = '<div class="chart-empty">Failed to load activity data</div>'; }
+}
+
+async function gcp_loadTools() {
+  var tbody = document.getElementById('gcp-tools-body');
+  if (!tbody) return;
+  try {
+    var res = await query(
+      "SELECT e.tool_name, " +
+      "SUM(CASE WHEN e.event_type = 'PreToolUse' THEN 1 ELSE 0 END) AS calls, " +
+      "SUM(CASE WHEN e.event_type = 'PostToolUseFailure' THEN 1 ELSE 0 END) AS failures " +
+      gcp_hookWhere() + " AND e.event_type IN ('PreToolUse','PostToolUse','PostToolUseFailure') " +
+      "AND e.tool_name != '' GROUP BY e.tool_name ORDER BY calls DESC"
+    );
+    var data = rowsToObjects(res);
+    if (!data.length) { tbody.innerHTML = '<tr><td colspan="4" class="loading">No tool data</td></tr>'; return; }
+    tbody.innerHTML = data.map(function(d) {
+      var calls = Number(d.calls) || 0;
+      var failures = Number(d.failures) || 0;
+      var rate = calls > 0 ? ((failures / calls) * 100).toFixed(1) + '%' : '0%';
+      var rateClass = failures > 0 ? 'style="color:var(--red)"' : '';
+      return '<tr><td>' + escapeHTML(d.tool_name) + '</td>' +
+        '<td>' + fmtNum(calls) + '</td>' +
+        '<td ' + rateClass + '>' + fmtNum(failures) + '</td>' +
+        '<td ' + rateClass + '>' + rate + '</td></tr>';
+    }).join('');
+  } catch { tbody.innerHTML = '<tr><td colspan="4" class="loading">Failed to load</td></tr>'; }
+}
+
+async function gcp_loadCostByModel() {
+  var tbody = document.getElementById('gcp-cost-body');
+  if (!tbody) return;
+  await loadPricing();
+  try {
+    var res = await query(
+      "SELECT model, " +
+      "SUM(COALESCE(output_tokens, 0)) AS out_tok, " +
+      "COUNT(*) AS msgs, " +
+      "SUM(CASE WHEN message_type IN ('user','tool_result','tool_use') THEN LENGTH(COALESCE(content,''))/4 ELSE 0 END) AS est_in_tok " +
+      gcp_msgWhere() + " AND model != '' GROUP BY model ORDER BY out_tok DESC"
+    );
+    var data = rowsToObjects(res);
+    if (!data.length) { tbody.innerHTML = '<tr><td colspan="4" class="loading">No cost data</td></tr>'; return; }
+    tbody.innerHTML = data.map(function(d) {
+      var price = sess_lookupPrice(d.model);
+      var estIn = Number(d.est_in_tok) || 0;
+      var out = Number(d.out_tok) || 0;
+      var cost = estIn * price.input / 1000000 + out * price.output / 1000000;
+      return '<tr><td>' + escapeHTML(d.model) + '</td>' +
+        '<td>' + fmtNum(out) + '</td>' +
+        '<td>' + fmtNum(Number(d.msgs) || 0) + '</td>' +
+        '<td class="cost">' + fmtCost(cost) + '</td></tr>';
+    }).join('');
+  } catch { tbody.innerHTML = '<tr><td colspan="4" class="loading">Failed to load</td></tr>'; }
+}
+
+// Tab navigation
+(function() {
+  var tabsEl = document.getElementById('gcp-tabs');
+  if (!tabsEl) return;
+  tabsEl.addEventListener('click', function(e) {
+    var tab = e.target.closest('.tab[data-gcptab]');
+    if (!tab) return;
+    tabsEl.querySelectorAll('.tab').forEach(function(t) { t.classList.remove('active'); });
+    tab.classList.add('active');
+    var tabName = tab.dataset.gcptab;
+    document.querySelectorAll('#view-copilot-cli .tab-content').forEach(function(tc) {
+      tc.classList.toggle('active', tc.id === 'tab-' + tabName);
+    });
+    if (tabName === 'gcp-tools') gcp_loadTools();
+    if (tabName === 'gcp-cost') gcp_loadCostByModel();
+    updateHash();
+  });
+})();

--- a/server/web/js/copilot-cli.js
+++ b/server/web/js/copilot-cli.js
@@ -173,11 +173,11 @@ async function gcp_loadTools() {
   if (!tbody) return;
   try {
     var res = await query(
-      "SELECT e.tool_name, " +
-      "SUM(CASE WHEN e.event_type = 'PreToolUse' THEN 1 ELSE 0 END) AS calls, " +
-      "SUM(CASE WHEN e.event_type = 'PostToolUseFailure' THEN 1 ELSE 0 END) AS failures " +
-      gcp_hookWhere() + " AND e.event_type IN ('PreToolUse','PostToolUse','PostToolUseFailure') " +
-      "AND e.tool_name != '' GROUP BY e.tool_name ORDER BY calls DESC"
+      "SELECT tool_name, " +
+      "SUM(CASE WHEN event_type = 'PreToolUse' THEN 1 ELSE 0 END) AS calls, " +
+      "SUM(CASE WHEN event_type = 'PostToolUseFailure' THEN 1 ELSE 0 END) AS failures " +
+      gcp_hookWhere() + " AND event_type IN ('PreToolUse','PostToolUse','PostToolUseFailure') " +
+      "AND tool_name != '' GROUP BY tool_name ORDER BY calls DESC"
     );
     var data = rowsToObjects(res);
     if (!data.length) { tbody.innerHTML = '<tr><td colspan="4" class="loading">No tool data</td></tr>'; return; }

--- a/server/web/js/sessions.js
+++ b/server/web/js/sessions.js
@@ -142,6 +142,7 @@ async function sess_loadList() {
     var sourceBadge;
     if (agentSrc === 'codex') sourceBadge = '<span class="badge badge-codex">Codex</span>';
     else if (agentSrc === 'openclaw') sourceBadge = '<span class="badge badge-oc">OC</span>';
+    else if (agentSrc === 'copilot_cli') sourceBadge = '<span class="badge badge-copilot">GH</span>';
     else sourceBadge = '<span class="badge badge-cc">CC</span>';
     var costStr = costMap[sid] != null ? fmtCost(costMap[sid]) : '\u2014';
 
@@ -437,7 +438,7 @@ async function sess_search() {
     if (content.length > 200) content = content.slice(0, 200) + '\u2026';
     var label = d.tool_name || d.msg_type || '';
     var sSrc = d.agent_source || '';
-    var sBadgeCls = sSrc === 'codex' ? 'badge-codex' : sSrc === 'openclaw' ? 'badge-oc' : 'badge-cc';
+    var sBadgeCls = sSrc === 'codex' ? 'badge-codex' : sSrc === 'openclaw' ? 'badge-oc' : sSrc === 'copilot_cli' ? 'badge-copilot' : 'badge-cc';
     html += '<div class="search-result-item clickable" onclick="sess_openDetail(\x27' + escapeJSString(d.session_id) + '\x27,\x27' + escapeJSString(sSrc) + '\x27,' + (ms || 0) + ')">';
     html += '<div class="search-result-meta"><span class="badge ' + sBadgeCls + '">' + escapeHTML((d.session_id || '').slice(0, 8)) + '</span> ';
     if (label) html += '<span class="tl-tool-name" style="font-size:12px">' + escapeHTML(label) + '</span> ';

--- a/server/web/js/views.js
+++ b/server/web/js/views.js
@@ -444,6 +444,17 @@ async function refreshCurrentView() {
       var activeCodexTab = document.querySelector('#cdx-tabs .tab.active');
       if (activeCodexTab) cdx_onTabChange(activeCodexTab.dataset.cdxtab);
     }
+  } else if (currentView === 'copilot-cli') {
+    hasData = await gcp_loadCards();
+    if (hasData) {
+      var activeGcpTab = document.querySelector('#gcp-tabs .tab.active');
+      if (activeGcpTab && activeGcpTab.dataset.gcptab) {
+        var tabName = activeGcpTab.dataset.gcptab;
+        if (tabName === 'gcp-overview') gcp_loadOverview();
+        else if (tabName === 'gcp-tools') gcp_loadTools();
+        else if (tabName === 'gcp-cost') gcp_loadCostByModel();
+      }
+    }
   } else if (currentView === 'sessions') {
     hasData = await sess_loadCards();
     if (hasData) {

--- a/server/web/js/views.js
+++ b/server/web/js/views.js
@@ -164,6 +164,7 @@ async function switchView(viewId, skipHash) {
   document.getElementById('view-claude-code').style.display = 'none';
   document.getElementById('view-codex').style.display = 'none';
   document.getElementById('view-openclaw').style.display = 'none';
+  document.getElementById('view-copilot-cli').style.display = 'none';
   document.getElementById('view-traces').style.display = 'none';
   document.getElementById('view-sessions').style.display = 'none';
   document.getElementById('view-prompts').style.display = 'none';
@@ -176,15 +177,7 @@ async function switchView(viewId, skipHash) {
     btn.classList.toggle('active', btn.dataset.view === viewId);
   });
 
-  // Copilot CLI tab reuses Sessions view with source filter pre-set.
-  var effectiveViewId = viewId;
-  if (viewId === 'copilot-cli') {
-    effectiveViewId = 'sessions';
-    var srcFilter = document.getElementById('sess-source-filter');
-    if (srcFilter) srcFilter.value = 'copilot_cli';
-  }
-
-  var viewEl = document.getElementById('view-' + effectiveViewId);
+  var viewEl = document.getElementById('view-' + viewId);
   if (viewEl) {
     var hasData = true;
     if (viewId === 'claude-code') {
@@ -197,7 +190,10 @@ async function switchView(viewId, skipHash) {
     } else if (viewId === 'openclaw') {
       hasData = await oc_loadCards();
       if (hasData) oc_loadOverview();
-    } else if (viewId === 'sessions' || viewId === 'copilot-cli') {
+    } else if (viewId === 'copilot-cli') {
+      hasData = await gcp_loadCards();
+      if (hasData) gcp_loadOverview();
+    } else if (viewId === 'sessions') {
       hasData = await sess_loadCards();
       if (hasData) sess_loadList();
     } else if (viewId === 'prompts') {

--- a/server/web/js/views.js
+++ b/server/web/js/views.js
@@ -36,6 +36,7 @@ async function detectDataSources() {
       ocMetrics: tables.filter(function(t) { return t.startsWith('openclaw_'); }),
       hasHookEvents: tables.includes('tma1_hook_events'),
       hasMessages: tables.includes('tma1_messages'),
+      hasCopilotCLI: false,
     };
     result.hasCodex = result.codexMetrics.length > 0;
     result.hasOpenClaw = result.ocMetrics.length > 0;
@@ -84,6 +85,15 @@ async function detectDataSources() {
         result.hasGenAITraces = true;
       }
     }
+    // Detect Copilot CLI sessions via hook events.
+    if (result.hasHookEvents) {
+      try {
+        var cpRes = await query(
+          "SELECT 1 FROM tma1_hook_events WHERE agent_source = 'copilot_cli' LIMIT 1"
+        );
+        result.hasCopilotCLI = (rows(cpRes) || []).length > 0;
+      } catch { /* ignore */ }
+    }
     return result;
   } catch {
     return {
@@ -93,6 +103,7 @@ async function detectDataSources() {
       hasGenAITraces: false,
       hasClaudeLogs: false,
       hasCodex: false,
+      hasCopilotCLI: false,
       ccMetrics: [],
       codexMetrics: [],
     };
@@ -165,7 +176,15 @@ async function switchView(viewId, skipHash) {
     btn.classList.toggle('active', btn.dataset.view === viewId);
   });
 
-  var viewEl = document.getElementById('view-' + viewId);
+  // Copilot CLI tab reuses Sessions view with source filter pre-set.
+  var effectiveViewId = viewId;
+  if (viewId === 'copilot-cli') {
+    effectiveViewId = 'sessions';
+    var srcFilter = document.getElementById('sess-source-filter');
+    if (srcFilter) srcFilter.value = 'copilot_cli';
+  }
+
+  var viewEl = document.getElementById('view-' + effectiveViewId);
   if (viewEl) {
     var hasData = true;
     if (viewId === 'claude-code') {
@@ -178,7 +197,7 @@ async function switchView(viewId, skipHash) {
     } else if (viewId === 'openclaw') {
       hasData = await oc_loadCards();
       if (hasData) oc_loadOverview();
-    } else if (viewId === 'sessions') {
+    } else if (viewId === 'sessions' || viewId === 'copilot-cli') {
       hasData = await sess_loadCards();
       if (hasData) sess_loadList();
     } else if (viewId === 'prompts') {
@@ -210,6 +229,7 @@ async function initViews() {
   if (hasCCView) views.push({ id: 'claude-code', label: t('view.claude_code') });
   if (dataSources.hasCodex) views.push({ id: 'codex', label: t('view.codex') });
   if (dataSources.hasOpenClaw) views.push({ id: 'openclaw', label: t('view.openclaw') });
+  if (dataSources.hasCopilotCLI) views.push({ id: 'copilot-cli', label: 'Copilot CLI' });
   if (dataSources.hasGenAITraces) views.push({ id: 'traces', label: t('view.otel_genai') });
   if (dataSources.hasHookEvents) views.push({ id: 'sessions', label: t('view.sessions') });
   if (dataSources.hasMessages) views.push({ id: 'prompts', label: t('view.prompts') });


### PR DESCRIPTION
## What

Add GitHub Copilot CLI as a supported agent in TMA1, with a dedicated dashboard view and JSONL session parser.

## Why

GitHub Copilot CLI (`ghcp`) stores rich session data in `~/.copilot/session-state/*/events.jsonl` with 19 event types including tool calls, subagent lifecycle, model changes, and user/assistant messages. TMA1 already supports Claude Code, Codex, and OpenClaw — this PR adds Copilot CLI as the fourth supported agent.

## Changes

### Backend (Go)
- **New parser**: `server/internal/transcript/copilot_cli.go` — scans `~/.copilot/session-state/` for JSONL files and parses events into `tma1_hook_events` and `tma1_messages`
- **Event mapping**: session.start/shutdown, user/assistant messages, tool execution (with failure detection), subagent lifecycle, model tracking, reasoning text as thinking messages, skill invocations
- **Session splitting**: Detects multiple logical sessions in a single JSONL file (Copilot CLI appends across restarts) and creates separate DB sessions
- **Batched scanning**: 10 concurrent watchers max, newest-first priority, 1s idle for completed sessions
- **Session IDs**: Namespaced as `cp:<sessionId>` to avoid cross-source collisions
- **9 unit tests**: All passing

### Frontend (JS/HTML/CSS)  
- **Dedicated dashboard view** (`server/web/js/copilot-cli.js`): KPI cards (Cost, Tokens, Tools, Sessions, Duration), sub-tabs (Overview, Tools, Cost, Sessions→), charts (token trend, cost trend, tool distribution, activity heatmap)
- **Green "GH" badges** in Sessions view for Copilot CLI sessions
- **Source filter** dropdown includes "Copilot CLI" option in Sessions and Prompts views
- **Top nav tab**: "Copilot CLI" appears when copilot_cli data is detected

### Canvas replay improvements
- Batch-process events <200ms apart in same frame (reduces setTimeout overhead)
- Cap idle delay to 500ms (was 2000ms) for faster replay
- Advance running tool ages by replay time gap to auto-expire stale spinners

### Registration
- `server/cmd/tma1-server/main.go`: Added `StartCopilotCLIScanner` goroutine with graceful shutdown

## How tested
- All existing tests pass (`go test ./internal/transcript/`)
- 9 new tests for Copilot CLI parser (session start, user message, assistant with reasoning, tool success/failure, model propagation, subagent lifecycle, dedup, session ID namespacing)
- Live tested with 200+ historical Copilot CLI sessions on Windows
- Verified data flow: hook events, messages, model tracking, cwd propagation
- Verified dashboard: KPI cards, charts, source filter, badges, replay
