### PR TITLE
fix: skills and timeout

### DIFF
--- a/claude-plugin/codex-skills/tma1-peer/SKILL.md
+++ b/claude-plugin/codex-skills/tma1-peer/SKILL.md
@@ -17,7 +17,10 @@ output on the current project, or when they explicitly type
 `/tma1-peer [agent] [count]`. Parse:
 
 - First positional arg (optional): peer agent name (`claude` / `claude_code`
-  / `openclaw` / `copilot` / `copilot_cli` / `all`).
+  / `openclaw` / `copilot` / `copilot_cli` / `all`). **If this arg is a bare
+  integer** (e.g. `/tma1-peer 3`), it is the count, not an agent — use
+  `agent_source: ""` (all peers) and that integer as the count. Do not reject
+  it as an unknown agent.
 - Second positional arg (optional): count of recent sessions to pull,
   integer 1-5, default 1.
 
@@ -46,7 +49,7 @@ the `get_peer_sessions` tool on that server with:
 | Argument        | Value                                                  |
 | --------------- | ------------------------------------------------------ |
 | `agent_source`  | the canonical name from the table above (or `""`)      |
-| `limit`         | the parsed count, default `1`, server-side clamp to `[1, 5]` |
+| `limit`         | the parsed count — **when the user gave a count you MUST pass it** (don't default to 1); omit only when none was given (server default `1`, clamp `[1, 5]`) |
 | `message_limit` | `30`                                                   |
 
 If your runtime addresses MCP tools by a prefixed name (for example

--- a/claude-plugin/commands/tma1-peer.md
+++ b/claude-plugin/commands/tma1-peer.md
@@ -17,6 +17,8 @@ file carries the essential rules for the explicit-invocation path.
   - `openclaw` → `openclaw`
   - `copilot` / `copilot_cli` → `copilot_cli`
   - `all` / `*` / empty → `""` (all peers, server excludes the caller)
+  - **a bare integer** (e.g. `/tma1-peer 3`) → it's the count, not an agent: use
+    `agent_source: ""` and that integer as the count. Do **not** reject it.
   - **Anything else** → reply `unknown peer agent "<X>"; available: codex, openclaw, copilot, all` and **STOP**.
 - 2nd token (optional) → integer, default `1`, clamped to `[1, 5]` server-side.
 
@@ -24,7 +26,8 @@ file carries the essential rules for the explicit-invocation path.
 
 `mcp__tma1__get_peer_sessions` with:
 - `agent_source`: the normalized name (or `""`)
-- `limit`: parsed count
+- `limit`: parsed count — **when a count was given, you MUST pass it** (don't
+  silently default to 1); e.g. `codex 3` → `limit: 3`
 - `message_limit`: `30`
 
 ## Use the response

--- a/claude-plugin/skills/tma1-peer/SKILL.md
+++ b/claude-plugin/skills/tma1-peer/SKILL.md
@@ -26,17 +26,23 @@ copy-pasting it manually.
 ## How to handle the invocation
 
 1. **Parse the user's arguments** after `/tma1-peer`:
-   - First token (optional): agent name
-   - Second token (optional): count (integer 1-5)
+   - First token (optional): agent name.
+   - **If the first token is a bare integer** (e.g. `/tma1-peer 3`), it is the
+     count, not an agent — use `agent_source: ""` (all peers) and that integer
+     as the count. Do NOT reject it as an unknown agent.
+   - Second token (optional): count (integer 1-5).
 2. **Normalize the agent name**:
    - `codex` → `codex`
    - `openclaw` → `openclaw`
    - `copilot` or `copilot_cli` → `copilot_cli`
    - `all`, `*`, or empty → `""` (means all peers, excludes Claude Code)
+   - a bare integer → treat as count (see step 1), `agent_source: ""`
    - **Anything else** → reply to the user: `unknown peer agent "<X>"; available: codex, openclaw, copilot, all` and STOP — do not call the tool with an unrecognized name.
 3. **Call the MCP tool `mcp__tma1__get_peer_sessions`** with:
    - `agent_source`: parsed agent (or empty string)
-   - `limit`: parsed count (default 1, server-side clamp to [1, 5])
+   - `limit`: the parsed count. **When the user gave a count, you MUST pass it**
+     — do not silently fall back to 1. Omit only when no count was supplied
+     (server default 1, clamp to [1, 5]). E.g. `codex 3` → `{agent_source: "codex", limit: 3}`.
    - `message_limit`: 30
 4. **Read the returned conversation messages** and use them as direct input
    for your next reasoning step. **Do not paraphrase** — when acting on

--- a/server/internal/hooks/codex-skills/tma1-peer/SKILL.md
+++ b/server/internal/hooks/codex-skills/tma1-peer/SKILL.md
@@ -17,7 +17,10 @@ output on the current project, or when they explicitly type
 `/tma1-peer [agent] [count]`. Parse:
 
 - First positional arg (optional): peer agent name (`claude` / `claude_code`
-  / `openclaw` / `copilot` / `copilot_cli` / `all`).
+  / `openclaw` / `copilot` / `copilot_cli` / `all`). **If this arg is a bare
+  integer** (e.g. `/tma1-peer 3`), it is the count, not an agent — use
+  `agent_source: ""` (all peers) and that integer as the count. Do not reject
+  it as an unknown agent.
 - Second positional arg (optional): count of recent sessions to pull,
   integer 1-5, default 1.
 
@@ -46,7 +49,7 @@ the `get_peer_sessions` tool on that server with:
 | Argument        | Value                                                  |
 | --------------- | ------------------------------------------------------ |
 | `agent_source`  | the canonical name from the table above (or `""`)      |
-| `limit`         | the parsed count, default `1`, server-side clamp to `[1, 5]` |
+| `limit`         | the parsed count — **when the user gave a count you MUST pass it** (don't default to 1); omit only when none was given (server default `1`, clamp `[1, 5]`) |
 | `message_limit` | `30`                                                   |
 
 If your runtime addresses MCP tools by a prefixed name (for example

--- a/server/internal/hooks/commands/tma1-peer.md
+++ b/server/internal/hooks/commands/tma1-peer.md
@@ -17,6 +17,8 @@ file carries the essential rules for the explicit-invocation path.
   - `openclaw` → `openclaw`
   - `copilot` / `copilot_cli` → `copilot_cli`
   - `all` / `*` / empty → `""` (all peers, server excludes the caller)
+  - **a bare integer** (e.g. `/tma1-peer 3`) → it's the count, not an agent: use
+    `agent_source: ""` and that integer as the count. Do **not** reject it.
   - **Anything else** → reply `unknown peer agent "<X>"; available: codex, openclaw, copilot, all` and **STOP**.
 - 2nd token (optional) → integer, default `1`, clamped to `[1, 5]` server-side.
 
@@ -24,7 +26,8 @@ file carries the essential rules for the explicit-invocation path.
 
 `mcp__tma1__get_peer_sessions` with:
 - `agent_source`: the normalized name (or `""`)
-- `limit`: parsed count
+- `limit`: parsed count — **when a count was given, you MUST pass it** (don't
+  silently default to 1); e.g. `codex 3` → `limit: 3`
 - `message_limit`: `30`
 
 ## Use the response

--- a/server/internal/hooks/skills/tma1-peer/SKILL.md
+++ b/server/internal/hooks/skills/tma1-peer/SKILL.md
@@ -26,17 +26,23 @@ copy-pasting it manually.
 ## How to handle the invocation
 
 1. **Parse the user's arguments** after `/tma1-peer`:
-   - First token (optional): agent name
-   - Second token (optional): count (integer 1-5)
+   - First token (optional): agent name.
+   - **If the first token is a bare integer** (e.g. `/tma1-peer 3`), it is the
+     count, not an agent — use `agent_source: ""` (all peers) and that integer
+     as the count. Do NOT reject it as an unknown agent.
+   - Second token (optional): count (integer 1-5).
 2. **Normalize the agent name**:
    - `codex` → `codex`
    - `openclaw` → `openclaw`
    - `copilot` or `copilot_cli` → `copilot_cli`
    - `all`, `*`, or empty → `""` (means all peers, excludes Claude Code)
+   - a bare integer → treat as count (see step 1), `agent_source: ""`
    - **Anything else** → reply to the user: `unknown peer agent "<X>"; available: codex, openclaw, copilot, all` and STOP — do not call the tool with an unrecognized name.
 3. **Call the MCP tool `mcp__tma1__get_peer_sessions`** with:
    - `agent_source`: parsed agent (or empty string)
-   - `limit`: parsed count (default 1, server-side clamp to [1, 5])
+   - `limit`: the parsed count. **When the user gave a count, you MUST pass it**
+     — do not silently fall back to 1. Omit only when no count was supplied
+     (server default 1, clamp to [1, 5]). E.g. `codex 3` → `{agent_source: "codex", limit: 3}`.
    - `message_limit`: 30
 4. **Read the returned conversation messages** and use them as direct input
    for your next reasoning step. **Do not paraphrase** — when acting on

--- a/server/internal/mcp/server.go
+++ b/server/internal/mcp/server.go
@@ -16,14 +16,26 @@ import (
 	"runtime/debug"
 	"strings"
 	"sync"
+	"time"
 )
 
 const (
 	protocolVersion = "2024-11-05"
 	serverName      = "tma1"
 
-	scannerInitBuf = 256 * 1024  // 256 KB initial
+	scannerInitBuf = 256 * 1024      // 256 KB initial
 	scannerMaxBuf  = 4 * 1024 * 1024 // 4 MB max — perception bundles can be larger than devtap's
+
+	// toolCallTimeout bounds every tools/call. All tools are read-only
+	// context queries against the local GreptimeDB; the perception HTTP
+	// client caps each query at 3s, but a tool that fans out (e.g.
+	// get_context_bundle: session state + anomalies + project state, or
+	// get_peer_sessions: cwd lookup + list + per-session enrichment) had no
+	// overall ceiling, so a slow GreptimeDB could stack those past 10s and
+	// make the agent appear hung. Applied once at the dispatch boundary so
+	// every tool — current and future — is bounded; the deadline propagates
+	// through context to every in-flight query, cancelling them together.
+	toolCallTimeout = 10 * time.Second
 )
 
 // ServerVersion can be overridden by callers (e.g. main package sets it from build ldflags).
@@ -182,7 +194,9 @@ func (s *Server) handle(ctx context.Context, req Request) {
 			})
 			return
 		}
-		result, err := t.Call(ctx, params.Arguments)
+		callCtx, cancel := context.WithTimeout(ctx, toolCallTimeout)
+		defer cancel()
+		result, err := t.Call(callCtx, params.Arguments)
 		if err != nil {
 			s.sendResult(req.ID, CallToolResult{
 				Content: []ContentBlock{{Type: "text", Text: fmt.Sprintf("Tool error: %v", err)}},

--- a/server/internal/mcp/tools.go
+++ b/server/internal/mcp/tools.go
@@ -139,12 +139,6 @@ func (t SessionStateTool) Call(ctx context.Context, args map[string]any) (CallTo
 	return CallToolResult{Content: []ContentBlock{{Type: "text", Text: string(out)}}}, nil
 }
 
-// peerQueryTimeout bounds the entire get_peer_sessions fan-out (cwd lookup +
-// session list + per-session enrichment, across peers). Generous enough for a
-// cold GreptimeDB serving a 5-session fetch, short enough that the agent never
-// perceives a hang.
-const peerQueryTimeout = 10 * time.Second
-
 // PeerSessionsTool returns recent session content from peer coding
 // agents that worked on the same project as the caller. "Peer" is
 // relative to whichever agent invoked the MCP tool: CC sees Codex /
@@ -201,14 +195,9 @@ func (t PeerSessionsTool) Call(ctx context.Context, args map[string]any) (CallTo
 		return errorResult("bundler not configured"), nil
 	}
 
-	// Bound the whole fan-out. The per-request HTTP client timeout (3s) caps
-	// each query individually, but the serial+parallel query tree (cwd lookup
-	// → session list → per-session enrichment, across peers) had no overall
-	// ceiling, so a slow GreptimeDB could drag the call past 20s and make the
-	// agent appear hung. This deadline propagates through context to every
-	// in-flight query so they cancel together rather than each burning 3s.
-	ctx, cancel := context.WithTimeout(ctx, peerQueryTimeout)
-	defer cancel()
+	// The overall fan-out deadline (cwd lookup → session list → per-session
+	// enrichment, across peers) is applied once at the MCP dispatch boundary
+	// (toolCallTimeout in server.go), so every tool is bounded uniformly.
 
 	agent, _ := args["agent_source"].(string)
 	limit := intArg(args, "limit", 1)

--- a/server/internal/mcp/tools.go
+++ b/server/internal/mcp/tools.go
@@ -139,6 +139,12 @@ func (t SessionStateTool) Call(ctx context.Context, args map[string]any) (CallTo
 	return CallToolResult{Content: []ContentBlock{{Type: "text", Text: string(out)}}}, nil
 }
 
+// peerQueryTimeout bounds the entire get_peer_sessions fan-out (cwd lookup +
+// session list + per-session enrichment, across peers). Generous enough for a
+// cold GreptimeDB serving a 5-session fetch, short enough that the agent never
+// perceives a hang.
+const peerQueryTimeout = 10 * time.Second
+
 // PeerSessionsTool returns recent session content from peer coding
 // agents that worked on the same project as the caller. "Peer" is
 // relative to whichever agent invoked the MCP tool: CC sees Codex /
@@ -194,6 +200,16 @@ func (t PeerSessionsTool) Call(ctx context.Context, args map[string]any) (CallTo
 	if t.Bundler == nil {
 		return errorResult("bundler not configured"), nil
 	}
+
+	// Bound the whole fan-out. The per-request HTTP client timeout (3s) caps
+	// each query individually, but the serial+parallel query tree (cwd lookup
+	// → session list → per-session enrichment, across peers) had no overall
+	// ceiling, so a slow GreptimeDB could drag the call past 20s and make the
+	// agent appear hung. This deadline propagates through context to every
+	// in-flight query so they cancel together rather than each burning 3s.
+	ctx, cancel := context.WithTimeout(ctx, peerQueryTimeout)
+	defer cancel()
+
 	agent, _ := args["agent_source"].(string)
 	limit := intArg(args, "limit", 1)
 	msgLimit := intArg(args, "message_limit", 20)
@@ -223,9 +239,9 @@ func (t PeerSessionsTool) Call(ctx context.Context, args map[string]any) (CallTo
 		// Surface the freshest session's age at the top so the agent can
 		// decide quickly whether the peer work is current.
 		payload["most_recent_session"] = map[string]any{
-			"agent_source":     sessions[0].AgentSource,
-			"session_id":       sessions[0].SessionID,
-			"last_activity":    sessions[0].LastActivityAt,
+			"agent_source":      sessions[0].AgentSource,
+			"session_id":        sessions[0].SessionID,
+			"last_activity":     sessions[0].LastActivityAt,
 			"last_activity_ago": sessions[0].LastActivityAgo,
 		}
 	} else {

--- a/server/internal/perception/peer.go
+++ b/server/internal/perception/peer.go
@@ -16,19 +16,19 @@ import (
 // when Codex invokes, CC is also a peer. The Bundler's Caller field
 // drives that exclusion when `agent_source` is left empty.
 type PeerSession struct {
-	SessionID         string        `json:"session_id"`
-	AgentSource       string        `json:"agent_source"`
-	StartedAt         time.Time     `json:"started_at"`
-	LastActivityAt    time.Time     `json:"last_activity_at"`
-	LastActivityAgo   string        `json:"last_activity_ago"` // human-friendly: "3m ago" / "2h ago"
-	DurationMinutes   int           `json:"duration_minutes"`
-	ToolCallCount     int           `json:"tool_call_count"`
-	TokensInput       int64         `json:"tokens_input"`
-	TokensOutput      int64         `json:"tokens_output"`
-	CWD               string        `json:"cwd,omitempty"`
-	Messages          []PeerMessage `json:"messages,omitempty"`
-	RecentToolNames   []string      `json:"recent_tool_names,omitempty"` // top 5
-	FilesTouched      []string      `json:"files_touched,omitempty"`     // unique paths
+	SessionID       string        `json:"session_id"`
+	AgentSource     string        `json:"agent_source"`
+	StartedAt       time.Time     `json:"started_at"`
+	LastActivityAt  time.Time     `json:"last_activity_at"`
+	LastActivityAgo string        `json:"last_activity_ago"` // human-friendly: "3m ago" / "2h ago"
+	DurationMinutes int           `json:"duration_minutes"`
+	ToolCallCount   int           `json:"tool_call_count"`
+	TokensInput     int64         `json:"tokens_input"`
+	TokensOutput    int64         `json:"tokens_output"`
+	CWD             string        `json:"cwd,omitempty"`
+	Messages        []PeerMessage `json:"messages,omitempty"`
+	RecentToolNames []string      `json:"recent_tool_names,omitempty"` // top 5
+	FilesTouched    []string      `json:"files_touched,omitempty"`     // unique paths
 }
 
 // PeerMessage is one conversation entry. Role is "user" / "assistant" /
@@ -59,6 +59,69 @@ var validPeerAgents = map[string]bool{
 	"codex":       true,
 	"openclaw":    true,
 	"copilot_cli": true,
+}
+
+// toolEventsSQL is the event_type set counted as tool calls (the
+// tool_call_count metric). Quoted, comma-joined for inlining into an IN list.
+const toolEventsSQL = "'PreToolUse','PostToolUse','PostToolUseFailure'"
+
+// activityEventsSQL is the event_type set that proves real agent/user
+// activity, as opposed to infra noise (SessionStart/SessionEnd, ConfigChange,
+// Notification, CwdChanged, InstructionsLoaded, ...). Ranking and the
+// "has-this-session-done-anything" filter use this set so an exited/resumed
+// shell whose newest event is a SessionStart/SessionEnd can't outrank a
+// session that actually did work.
+//
+// UserPromptSubmit is INCLUDED on purpose: a session where the user typed a
+// prompt but no tool has fired yet is genuine, current activity worth
+// surfacing — such a session is KEPT even though tool_call_count == 0. This
+// is deliberately NOT "drop tool_call_count == 0".
+const activityEventsSQL = "'PreToolUse','PostToolUse','PostToolUseFailure','UserPromptSubmit'"
+
+// buildPeerSessionListSQL builds the pass-2 aggregate query for peer sessions.
+// `sids` are already SQL-quoted session_id literals. cwd uses MAX(cwd) (not an
+// activity filter) because some agents — notably Codex — only set cwd on
+// SessionStart; started/last/ordering use activity events only. The HAVING
+// drops infra-only/exit shells (see activityEventsSQL).
+func buildPeerSessionListSQL(sids []string, limit, sinceMin int) string {
+	return fmt.Sprintf(
+		`SELECT session_id,
+		        MAX(agent_source) AS agent_source,
+		        MAX(cwd)          AS cwd,
+		        CAST(MIN(CASE WHEN event_type IN (%[1]s) THEN ts END) AS BIGINT) AS started_ms,
+		        CAST(MAX(CASE WHEN event_type IN (%[1]s) THEN ts END) AS BIGINT) AS last_ms,
+		        SUM(CASE WHEN event_type IN (%[2]s) THEN 1 ELSE 0 END) AS tool_call_count
+		 FROM tma1_hook_events
+		 WHERE session_id IN (%[3]s)
+		   AND ts > now() - INTERVAL '%[5]d minutes'
+		 GROUP BY session_id
+		 HAVING SUM(CASE WHEN event_type IN (%[1]s) THEN 1 ELSE 0 END) > 0
+		 ORDER BY last_ms DESC
+		 LIMIT %[4]d`,
+		activityEventsSQL, toolEventsSQL, strings.Join(sids, ","), limit, sinceMin,
+	)
+}
+
+// buildLatestSessionForCWDSQL builds the query that finds the most recent
+// session for a cwd, ranked by last *activity* event. The cwd match runs as an
+// inner subquery over all events (preserving Codex's SessionStart-only cwd);
+// the outer query keeps only sessions with activity and ranks by their newest
+// activity event. `cwd` must be unescaped — it is escaped here.
+func buildLatestSessionForCWDSQL(cwd string) string {
+	return fmt.Sprintf(
+		`SELECT session_id FROM tma1_hook_events
+		 WHERE session_id IN (
+		     SELECT session_id FROM tma1_hook_events
+		     WHERE cwd = '%s' AND session_id != ''
+		       AND ts > now() - INTERVAL '6 hours'
+		 )
+		   AND event_type IN (%s)
+		   AND ts > now() - INTERVAL '6 hours'
+		 GROUP BY session_id
+		 ORDER BY MAX(ts) DESC
+		 LIMIT 1`,
+		escapeSQL(cwd), activityEventsSQL,
+	)
 }
 
 // GetPeerSessions returns the N most recent sessions for `agentSource`
@@ -214,29 +277,20 @@ func (b *Bundler) getPeerSessionsOneAgent(
 		return nil, nil
 	}
 
-	// Step 2: aggregate metadata over the matched session_ids. event_type
-	// filter scopes the tool_call_count to actual tool events but the row
-	// is included even if there are 0 (SessionStart-only sessions still
-	// surface so the caller learns they exist).
-	listSQL := fmt.Sprintf(
-		`SELECT session_id,
-		        MAX(agent_source)             AS agent_source,
-		        MAX(cwd)                      AS cwd,
-		        CAST(MIN(ts) AS BIGINT)       AS started_ms,
-		        CAST(MAX(ts) AS BIGINT)       AS last_ms,
-		        SUM(CASE WHEN event_type IN ('PreToolUse','PostToolUse','PostToolUseFailure') THEN 1 ELSE 0 END) AS tool_call_count
-		 FROM tma1_hook_events
-		 WHERE session_id IN (%s)
-		 GROUP BY session_id
-		 ORDER BY last_ms DESC
-		 LIMIT %d`,
-		strings.Join(sids, ","), limit,
-	)
-	_, rows, err := b.client.Query(ctx, listSQL)
+	// Step 2: aggregate metadata over the matched session_ids, ranking by
+	// last *activity* event so an exited/resumed shell whose newest event is
+	// infra (SessionStart/SessionEnd/ConfigChange) can't outrank a session
+	// that actually did work. Infra-only sessions are dropped by the HAVING.
+	_, rows, err := b.client.Query(ctx, buildPeerSessionListSQL(sids, limit, sinceMin))
 	if err != nil {
 		return nil, fmt.Errorf("list peer sessions: %w", err)
 	}
 
+	// Build the session skeletons first (cheap, no I/O), then enrich them
+	// concurrently. enrichPeerSession is several HTTP roundtrips per session;
+	// running them serially made a limit=5 fetch ~5x slower than necessary
+	// against a loaded GreptimeDB. Enrich into pre-sized slots so the
+	// ORDER BY last_ms DESC order from the query is preserved.
 	out := make([]PeerSession, 0, len(rows))
 	for _, r := range rows {
 		sid := stringAt(r, 0)
@@ -260,9 +314,18 @@ func (b *Bundler) getPeerSessionsOneAgent(
 		// "3m ago" string matches the format the agent already sees in
 		// `<tma1-context>`. Empty when no LastActivityAt.
 		ps.LastActivityAgo = relativeAge(ps.LastActivityAt)
-		b.enrichPeerSession(ctx, &ps, messageLimit)
 		out = append(out, ps)
 	}
+
+	var wg sync.WaitGroup
+	for i := range out {
+		wg.Add(1)
+		go func(ps *PeerSession) {
+			defer wg.Done()
+			b.enrichPeerSession(ctx, ps, messageLimit)
+		}(&out[i])
+	}
+	wg.Wait()
 	return out, nil
 }
 

--- a/server/internal/perception/peer_test.go
+++ b/server/internal/perception/peer_test.go
@@ -19,9 +19,9 @@ func TestNormalizePeerAgent(t *testing.T) {
 		{"codex", "codex"},
 		{"CODEX", "codex"},
 		{"openclaw", "openclaw"},
-		{"copilot", "copilot_cli"},       // alias
-		{"Copilot", "copilot_cli"},       // case-insensitive alias
-		{"copilot-cli", "copilot_cli"},   // hyphen alias
+		{"copilot", "copilot_cli"},     // alias
+		{"Copilot", "copilot_cli"},     // case-insensitive alias
+		{"copilot-cli", "copilot_cli"}, // hyphen alias
 		{"github-copilot", "copilot_cli"},
 		{"copilot_cli", "copilot_cli"},
 		// CC aliases — the Codex skill table documents these as valid
@@ -333,4 +333,65 @@ func TestDedupPeerMessages(t *testing.T) {
 			t.Errorf("order broken: %+v", got)
 		}
 	})
+}
+
+func TestBuildPeerSessionListSQL(t *testing.T) {
+	sids := []string{"'a'", "'b'"}
+	got := buildPeerSessionListSQL(sids, 3, 90)
+
+	// Ranking and started/last must use the activity-event set so an
+	// exited/resumed shell (newest event is infra) can't outrank real work.
+	if !strings.Contains(got, "MAX(CASE WHEN event_type IN ("+activityEventsSQL+") THEN ts END)") {
+		t.Errorf("last_ms not computed over activity events:\n%s", got)
+	}
+	if !strings.Contains(got, "MIN(CASE WHEN event_type IN ("+activityEventsSQL+") THEN ts END)") {
+		t.Errorf("started_ms not computed over activity events:\n%s", got)
+	}
+	// Infra-only / exit shells must be dropped.
+	if !strings.Contains(got, "HAVING SUM(CASE WHEN event_type IN ("+activityEventsSQL+") THEN 1 ELSE 0 END) > 0") {
+		t.Errorf("missing HAVING activity > 0:\n%s", got)
+	}
+	// tool_call_count stays on the narrower tool-event set.
+	if !strings.Contains(got, "SUM(CASE WHEN event_type IN ("+toolEventsSQL+") THEN 1 ELSE 0 END) AS tool_call_count") {
+		t.Errorf("tool_call_count not on tool events:\n%s", got)
+	}
+	if !strings.Contains(got, "ORDER BY last_ms DESC") {
+		t.Errorf("not ordered by last_ms DESC:\n%s", got)
+	}
+	if !strings.Contains(got, "session_id IN ('a','b')") {
+		t.Errorf("session_id IN list missing:\n%s", got)
+	}
+	if !strings.Contains(got, "ts > now() - INTERVAL '90 minutes'") {
+		t.Errorf("since_min activity window missing:\n%s", got)
+	}
+	if !strings.Contains(got, "LIMIT 3") {
+		t.Errorf("limit not applied:\n%s", got)
+	}
+}
+
+func TestBuildLatestSessionForCWDSQL(t *testing.T) {
+	got := buildLatestSessionForCWDSQL("/Users/dennis/tma1")
+
+	// cwd match runs as a subquery over ALL events (Codex sets cwd only on
+	// SessionStart), but the winner is ranked by its newest ACTIVITY event.
+	if !strings.Contains(got, "WHERE cwd = '/Users/dennis/tma1'") {
+		t.Errorf("cwd subquery filter missing:\n%s", got)
+	}
+	if !strings.Contains(got, "AND event_type IN ("+activityEventsSQL+")") {
+		t.Errorf("activity filter on outer query missing:\n%s", got)
+	}
+	if strings.Count(got, "ts > now() - INTERVAL '6 hours'") != 2 {
+		t.Errorf("cwd and activity windows should both be bounded:\n%s", got)
+	}
+	if !strings.Contains(got, "ORDER BY MAX(ts) DESC") || !strings.Contains(got, "LIMIT 1") {
+		t.Errorf("not ranked by MAX(ts) DESC LIMIT 1:\n%s", got)
+	}
+}
+
+func TestBuildLatestSessionForCWDSQLEscapesQuote(t *testing.T) {
+	// A cwd with an apostrophe must not break out of the string literal.
+	got := buildLatestSessionForCWDSQL("/Users/o'brien/tma1")
+	if !strings.Contains(got, "/Users/o''brien/tma1") {
+		t.Errorf("single quote not escaped:\n%s", got)
+	}
 }

--- a/server/internal/perception/session.go
+++ b/server/internal/perception/session.go
@@ -53,14 +53,12 @@ func (b *Bundler) LatestSessionForCWD(ctx context.Context, cwd string) (string, 
 	if cwd == "" {
 		return "", nil
 	}
-	sql := fmt.Sprintf(
-		`SELECT session_id FROM tma1_hook_events
-		 WHERE cwd = '%s' AND session_id != ''
-		   AND ts > now() - INTERVAL '6 hours'
-		 ORDER BY ts DESC LIMIT 1`,
-		escapeSQL(cwd),
-	)
-	_, rows, err := b.client.Query(ctx, sql)
+	// Rank by last *activity* event, not last event: an exited/resumed shell
+	// whose newest event is infra (SessionStart/SessionEnd/ConfigChange) must
+	// not win over a session that actually did work in the same cwd. The cwd
+	// match runs as a subquery over all events so Codex's SessionStart-only
+	// cwd still matches. See buildLatestSessionForCWDSQL.
+	_, rows, err := b.client.Query(ctx, buildLatestSessionForCWDSQL(cwd))
 	if err != nil || len(rows) == 0 {
 		return "", err
 	}


### PR DESCRIPTION

Fixed:

* wrong argument in skills to retrieve other agent's session.
* timeout of mcp calling
* get the latest session with empty conversations.
