### PR TITLE
fix(sensor/git): stop fd exhaustion from watching markerless roots

### DIFF
--- a/server/internal/sensor/git/sensor.go
+++ b/server/internal/sensor/git/sensor.go
@@ -121,11 +121,25 @@ func (s *Sensor) Stop(root string) {
 	}
 }
 
-// resolveProjectRoot returns the project root for cwd. It deliberately
-// duplicates the perception package's helper rather than importing it to
-// keep the sensor package's dependency graph tight: perception imports git
-// would be fine, but git importing perception would create a cycle later
-// when perception starts reading external_changes back.
+// resolveProjectRoot returns the project root for cwd, or "" when cwd
+// belongs to no recognisable project. A root is recognised only when cwd or
+// an ancestor holds a .git dir or a language project marker (go.mod,
+// package.json, ...).
+//
+// Returning "" for unmarked directories is deliberate. The previous
+// fallback returned cwd itself, so an agent whose hook CWD was "/" — or any
+// markerless directory like ~/Downloads — made the watcher recursively
+// register fsnotify over that whole tree. On macOS every watched path costs
+// a file descriptor (kqueue opens the dir and its entries), so a single "/"
+// root walked /Applications, /Library and /System and exhausted
+// kern.maxfilesperproc, wedging the HTTP listener with EMFILE. No marker,
+// no watch.
+//
+// It deliberately duplicates the perception package's helper rather than
+// importing it to keep the sensor package's dependency graph tight:
+// perception importing git would be fine, but git importing perception
+// would create a cycle later when perception starts reading
+// external_changes back.
 func resolveProjectRoot(cwd string) string {
 	cwd = strings.TrimSpace(cwd)
 	if cwd == "" {
@@ -153,7 +167,7 @@ func resolveProjectRoot(cwd string) string {
 		}
 		dir = parent
 	}
-	return abs
+	return "" // no project marker found — refuse to watch a bare directory
 }
 
 func findAncestorWith(start, marker string) string {

--- a/server/internal/sensor/git/sensor_test.go
+++ b/server/internal/sensor/git/sensor_test.go
@@ -120,6 +120,39 @@ func TestSensorObserveDetectsRealFileWrite(t *testing.T) {
 	}
 }
 
+func TestResolveProjectRootRejectsUnmarked(t *testing.T) {
+	// A markerless directory must not become a watch root. This is the fix
+	// for the fd-exhaustion bug: a hook CWD of "/" (or ~/Downloads) used to
+	// fall back to itself and get watched recursively, opening one fd per
+	// file under /Applications, /Library, ... until the process hit
+	// kern.maxfilesperproc and the HTTP listener died with EMFILE.
+	if got := resolveProjectRoot(t.TempDir()); got != "" {
+		t.Errorf("bare dir: resolveProjectRoot = %q, want \"\"", got)
+	}
+	if got := resolveProjectRoot("/"); got != "" {
+		t.Errorf(`resolveProjectRoot("/") = %q, want ""`, got)
+	}
+	if got := resolveProjectRoot(""); got != "" {
+		t.Errorf(`resolveProjectRoot("") = %q, want ""`, got)
+	}
+
+	withGit := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(withGit, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if got := resolveProjectRoot(withGit); got != withGit {
+		t.Errorf(".git dir: resolveProjectRoot = %q, want %q", got, withGit)
+	}
+
+	withGoMod := t.TempDir()
+	if err := os.WriteFile(filepath.Join(withGoMod, "go.mod"), []byte("module x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := resolveProjectRoot(withGoMod); got != withGoMod {
+		t.Errorf("go.mod: resolveProjectRoot = %q, want %q", got, withGoMod)
+	}
+}
+
 func TestResolveProjectRootPrefersGitOverGoMod(t *testing.T) {
 	root := t.TempDir()
 	_ = os.MkdirAll(filepath.Join(root, ".git"), 0o755)

--- a/server/internal/sensor/git/watcher.go
+++ b/server/internal/sensor/git/watcher.go
@@ -23,6 +23,15 @@ const (
 	// fire within this window (editor "atomic save" sequences typically
 	// emit Create + Remove + Write within a few ms).
 	fsEventDebounce = 500 * time.Millisecond
+
+	// maxWatchDirs bounds how many directories one watcher tries to register
+	// with fsnotify. On macOS each watched dir costs file descriptors (kqueue
+	// opens the dir and its entries), so an unbounded walk over a giant
+	// monorepo — or a root that resolved too wide — can exhaust the process
+	// fd limit and wedge the HTTP listener with EMFILE. 2048 covers real
+	// projects with headroom; past it we stop adding and warn once rather
+	// than leak descriptors or keep walking after Add starts failing.
+	maxWatchDirs = 2048
 )
 
 // projectWatcher watches one project root. It blends fsnotify (file
@@ -77,9 +86,14 @@ func (w *projectWatcher) start() error {
 	// Best-effort recursive watch by walking once at start. Subdirectories
 	// created later don't auto-attach — for Phase 1.2 this is acceptable;
 	// most projects have stable directory layouts.
-	if err := addRecursive(fsw, w.cfg.Root); err != nil {
+	added, capped, err := addRecursive(fsw, w.cfg.Root, maxWatchDirs)
+	if err != nil {
 		_ = fsw.Close()
 		return err
+	}
+	if capped {
+		w.logger.Warn("git watcher: hit directory watch cap; deeper subdirs unwatched",
+			"root", w.cfg.Root, "cap", maxWatchDirs, "watched", added)
 	}
 
 	w.wg.Add(2)
@@ -257,12 +271,12 @@ var staticIgnoreFragments = []string{
 	"/dist/",
 	"/build/",
 	"/target/",
-	"/bin/",          // Go build outputs (server/bin, tooling). Dropped here
-	"/out/",          // Java / generic build output dir
-	"/vendor/",       // Go / PHP / Ruby vendored deps
-	"/.venv/",        // Python venv
-	"/venv/",         // Python venv (alt)
-	"/.tma1/",        // tma1's own data dir (avoids self-noise loop)
+	"/bin/",    // Go build outputs (server/bin, tooling). Dropped here
+	"/out/",    // Java / generic build output dir
+	"/vendor/", // Go / PHP / Ruby vendored deps
+	"/.venv/",  // Python venv
+	"/venv/",   // Python venv (alt)
+	"/.tma1/",  // tma1's own data dir (avoids self-noise loop)
 	"/.idea/",
 	"/.vscode/",
 	"/__pycache__/",
@@ -273,6 +287,24 @@ var staticIgnoreFragments = []string{
 
 var staticIgnoreSuffixes = []string{
 	".pyc", ".swp", ".swo", ".log", ".DS_Store",
+}
+
+// systemRootPrefixes are absolute, filesystem-root OS trees we never walk.
+// Matched by PREFIX (not substring like staticIgnoreFragments) so a project
+// that merely contains — or is named — "Library" / "System" / "Applications"
+// is still watched; only the real OS trees mounted at "/" are blocked.
+//
+// Defence in depth behind resolveProjectRoot, which already refuses any root
+// without a .git / project marker. It exists because a single misresolved
+// "/" root walking /Applications was enough to exhaust file descriptors.
+// User-level trees (~/Library) are deliberately absent: they carry no marker
+// so P0 already declines them, and the fd weight lives in the root-level
+// /Applications anyway. /Volumes is absent too — projects legitimately live
+// on external disks.
+var systemRootPrefixes = []string{
+	"/Applications/",
+	"/Library/",
+	"/System/",
 }
 
 // staticShouldIgnorePath is the project-agnostic ignore check. Tests
@@ -292,6 +324,11 @@ func staticShouldIgnorePath(p string) bool {
 	normalized := strings.ReplaceAll(p, "\\", "/")
 	for _, frag := range staticIgnoreFragments {
 		if strings.Contains(normalized, frag) {
+			return true
+		}
+	}
+	for _, prefix := range systemRootPrefixes {
+		if strings.HasPrefix(normalized, prefix) {
 			return true
 		}
 	}
@@ -329,11 +366,18 @@ func (w *projectWatcher) shouldIgnorePath(p string) bool {
 	return false
 }
 
-// addRecursive walks root and registers every directory with the watcher,
-// skipping ignored paths. Errors on individual descents are logged but not
-// fatal — partial coverage is better than none.
-func addRecursive(fsw *fsnotify.Watcher, root string) error {
-	return filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+// addRecursive walks root and tries to register up to limit directories with
+// the watcher, skipping ignored paths. It returns the number of directories
+// successfully added and whether the limit stopped the walk. Errors on
+// individual descents are logged but not fatal — partial coverage is better
+// than none. Hitting limit stops the walk (caller warns) so one pathological
+// root can't exhaust file descriptors or keep walking after Add starts
+// failing.
+func addRecursive(fsw *fsnotify.Watcher, root string, limit int) (int, bool, error) {
+	added := 0
+	attempted := 0
+	capped := false
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return nil
 		}
@@ -343,9 +387,17 @@ func addRecursive(fsw *fsnotify.Watcher, root string) error {
 		if staticShouldIgnorePath(path + "/") {
 			return filepath.SkipDir
 		}
-		_ = fsw.Add(path)
+		if attempted >= limit {
+			capped = true
+			return filepath.SkipAll
+		}
+		attempted++
+		if fsw.Add(path) == nil {
+			added++
+		}
 		return nil
 	})
+	return added, capped, err
 }
 
 // readGitHead returns the SHA of HEAD or "" on failure. The context lets a

--- a/server/internal/sensor/git/watcher.go
+++ b/server/internal/sensor/git/watcher.go
@@ -86,13 +86,13 @@ func (w *projectWatcher) start() error {
 	// Best-effort recursive watch by walking once at start. Subdirectories
 	// created later don't auto-attach — for Phase 1.2 this is acceptable;
 	// most projects have stable directory layouts.
-	added, capped, err := addRecursive(fsw, w.cfg.Root, maxWatchDirs)
+	added, stopped, err := addRecursive(fsw, w.cfg.Root, maxWatchDirs)
 	if err != nil {
 		_ = fsw.Close()
 		return err
 	}
-	if capped {
-		w.logger.Warn("git watcher: hit directory watch cap; deeper subdirs unwatched",
+	if stopped {
+		w.logger.Warn("git watcher: stopped registering watches early (cap or fd limit); deeper subdirs unwatched",
 			"root", w.cfg.Root, "cap", maxWatchDirs, "watched", added)
 	}
 
@@ -366,17 +366,19 @@ func (w *projectWatcher) shouldIgnorePath(p string) bool {
 	return false
 }
 
-// addRecursive walks root and tries to register up to limit directories with
-// the watcher, skipping ignored paths. It returns the number of directories
-// successfully added and whether the limit stopped the walk. Errors on
-// individual descents are logged but not fatal — partial coverage is better
-// than none. Hitting limit stops the walk (caller warns) so one pathological
-// root can't exhaust file descriptors or keep walking after Add starts
-// failing.
+// addRecursive walks root and registers up to limit directories with the
+// watcher, skipping ignored paths. It returns the number of directories
+// successfully added and whether the walk stopped early — either because it
+// hit limit or because fsnotify.Add began failing. Walk errors are non-fatal
+// (partial coverage beats none).
+//
+// Stopping on the first Add failure matters: once Add returns EMFILE/ENOSPC
+// the fd/watch table is full, so every further Add fails too. Continuing the
+// traversal would just burn time and IO on a doomed walk — exactly the cost
+// this watcher cap exists to avoid.
 func addRecursive(fsw *fsnotify.Watcher, root string, limit int) (int, bool, error) {
 	added := 0
-	attempted := 0
-	capped := false
+	stopped := false
 	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return nil
@@ -387,17 +389,18 @@ func addRecursive(fsw *fsnotify.Watcher, root string, limit int) (int, bool, err
 		if staticShouldIgnorePath(path + "/") {
 			return filepath.SkipDir
 		}
-		if attempted >= limit {
-			capped = true
+		if added >= limit {
+			stopped = true // hit the watch cap
 			return filepath.SkipAll
 		}
-		attempted++
-		if fsw.Add(path) == nil {
-			added++
+		if fsw.Add(path) != nil {
+			stopped = true // Add failing (fd/watch exhaustion) — abandon the walk
+			return filepath.SkipAll
 		}
+		added++
 		return nil
 	})
-	return added, capped, err
+	return added, stopped, err
 }
 
 // readGitHead returns the SHA of HEAD or "" on failure. The context lets a

--- a/server/internal/sensor/git/watcher_test.go
+++ b/server/internal/sensor/git/watcher_test.go
@@ -76,12 +76,12 @@ func TestAddRecursiveRespectsCap(t *testing.T) {
 		}
 		defer fsw.Close()
 
-		added, capped, err := addRecursive(fsw, root, 3)
+		added, stopped, err := addRecursive(fsw, root, 3)
 		if err != nil {
 			t.Fatal(err)
 		}
-		if !capped {
-			t.Fatal("capped = false, want true")
+		if !stopped {
+			t.Fatal("stopped = false, want true")
 		}
 		if added != 3 {
 			t.Errorf("added = %d, want 3 (cap reached, 11 dirs available)", added)
@@ -95,12 +95,12 @@ func TestAddRecursiveRespectsCap(t *testing.T) {
 		}
 		defer fsw.Close()
 
-		added, capped, err := addRecursive(fsw, root, 100)
+		added, stopped, err := addRecursive(fsw, root, 100)
 		if err != nil {
 			t.Fatal(err)
 		}
-		if capped {
-			t.Fatal("capped = true, want false")
+		if stopped {
+			t.Fatal("stopped = true, want false")
 		}
 		if added != 11 { // root + 10 subdirs
 			t.Errorf("added = %d, want 11 (root + 10 subdirs)", added)
@@ -116,12 +116,12 @@ func TestAddRecursiveRespectsCap(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		added, capped, err := addRecursive(fsw, root, 3)
+		added, stopped, err := addRecursive(fsw, root, 3)
 		if err != nil {
 			t.Fatal(err)
 		}
-		if !capped {
-			t.Fatal("capped = false, want true")
+		if !stopped {
+			t.Fatal("stopped = false, want true")
 		}
 		if added != 0 {
 			t.Errorf("added = %d, want 0 after watcher is closed", added)

--- a/server/internal/sensor/git/watcher_test.go
+++ b/server/internal/sensor/git/watcher_test.go
@@ -1,6 +1,9 @@
 package git
 
 import (
+	"os"
+	"path/filepath"
+	"strconv"
 	"testing"
 
 	"github.com/fsnotify/fsnotify"
@@ -15,11 +18,11 @@ func TestStaticShouldIgnorePath(t *testing.T) {
 		{"/repo/node_modules/foo/index.js", true},
 		{"/repo/dist/bundle.js", true},
 		{"/repo/build/x.o", true},
-		{"/repo/bin/tma1-server", true},      // dogfood report: bin/ was leaking
+		{"/repo/bin/tma1-server", true}, // dogfood report: bin/ was leaking
 		{"/repo/out/foo.class", true},
 		{"/repo/vendor/x.go", true},
 		{"/repo/.venv/bin/python", true},
-		{"/repo/.tma1/state.json", true},     // tma1's own data dir
+		{"/repo/.tma1/state.json", true}, // tma1's own data dir
 		{"/repo/__pycache__/x.cpython-311.pyc", true},
 		{"/repo/x.pyc", true},
 		{"/repo/.DS_Store", true},
@@ -30,6 +33,18 @@ func TestStaticShouldIgnorePath(t *testing.T) {
 		{"/repo/main.go.tmp.27019.4ef42db74560", true},
 		{"/repo/src/main.go", false},
 		{"/repo/README.md", false},
+		// Root-level macOS system trees — matched by prefix.
+		{"/Applications/Foo.app/Contents/MacOS/foo", true},
+		{"/Library/Caches/x", true},
+		{"/System/Library/Frameworks/x", true},
+		// A project named or containing "Library"/"System"/"Applications" must
+		// still be watched — prefix matching only blocks the real OS trees at
+		// "/", not same-named subdirs (Unity Library/, ECS System/, ...).
+		{"/Users/dennis/code/Library/src/main.go", false},
+		{"/Users/dennis/code/game/System/world.go", false},
+		{"/Users/dennis/Library/Caches/y", false}, // ~/Library: P0's job, not this guard
+		// External disks are NOT blocked — projects legitimately live there.
+		{"/Volumes/Disk/proj/src/main.go", false},
 		// Windows-style paths: fsnotify hands us backslashes on
 		// Windows. Without ToSlash normalization these never matched
 		// any POSIX fragment, so the recursive watcher descended into
@@ -44,6 +59,74 @@ func TestStaticShouldIgnorePath(t *testing.T) {
 			t.Errorf("staticShouldIgnorePath(%q) = %v, want %v", tc.path, got, tc.want)
 		}
 	}
+}
+
+func TestAddRecursiveRespectsCap(t *testing.T) {
+	root := t.TempDir()
+	for i := 0; i < 10; i++ {
+		if err := os.MkdirAll(filepath.Join(root, "d"+strconv.Itoa(i)), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	t.Run("cap truncates the walk", func(t *testing.T) {
+		fsw, err := fsnotify.NewWatcher()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer fsw.Close()
+
+		added, capped, err := addRecursive(fsw, root, 3)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !capped {
+			t.Fatal("capped = false, want true")
+		}
+		if added != 3 {
+			t.Errorf("added = %d, want 3 (cap reached, 11 dirs available)", added)
+		}
+	})
+
+	t.Run("ample cap watches root + all subdirs", func(t *testing.T) {
+		fsw, err := fsnotify.NewWatcher()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer fsw.Close()
+
+		added, capped, err := addRecursive(fsw, root, 100)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if capped {
+			t.Fatal("capped = true, want false")
+		}
+		if added != 11 { // root + 10 subdirs
+			t.Errorf("added = %d, want 11 (root + 10 subdirs)", added)
+		}
+	})
+
+	t.Run("cap still stops when add fails", func(t *testing.T) {
+		fsw, err := fsnotify.NewWatcher()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := fsw.Close(); err != nil {
+			t.Fatal(err)
+		}
+
+		added, capped, err := addRecursive(fsw, root, 3)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !capped {
+			t.Fatal("capped = false, want true")
+		}
+		if added != 0 {
+			t.Errorf("added = %d, want 0 after watcher is closed", added)
+		}
+	})
 }
 
 func TestClassifyFsOp(t *testing.T) {


### PR DESCRIPTION
## Problem

tma1-server would intermittently stop serving the dashboard (localhost:14318 went blank). Root cause was file-descriptor exhaustion, not GreptimeDB:

- The git watcher walks the project root and registers one fsnotify watch per directory. On macOS (kqueue) every watched path holds a file descriptor.
- `resolveProjectRoot` fell back to returning the raw cwd when a directory had no `.git` / project marker. A hook reporting CWD `/` therefore made the watcher recurse over the whole filesystem (`/Applications`, `/Library`, `/System`), opening ~180k fds and hitting `kern.maxfilesperproc` (184320 on the affected machine).
- `accept()` then failed with `EMFILE` ("too many open files") and the HTTP listener stopped accepting connections. The process stayed alive but unresponsive, so `launchd KeepAlive` did not restart it.

## Fix

- **P0** — `resolveProjectRoot` returns `""` for markerless directories. No `.git`/`go.mod`/`package.json`/... marker means no watch, instead of falling back to cwd itself. A bare `/` or `~/Downloads` can no longer become a watch root.
- **P1** — `addRecursive` caps registrations at `maxWatchDirs` (2048) and stops the walk once `Add` begins failing, so no single root can drain the fd table. Root-level OS trees (`/Applications`, `/Library`, `/System`) are blocked by **prefix** match (not substring), so a project that merely contains — or is named — `Library` / `System` is still watched.

## Behavior change

Running an agent in a directory with no project marker no longer emits `external_changes` events. Such a directory is not a meaningful "project"; the trade is worth it to eliminate the fd leak.

## Tests

- `resolveProjectRoot`: `/`, empty, and markerless dirs → `""`; `.git` / `go.mod` → that dir
- `addRecursive`: cap truncates the walk; ample cap watches root + all subdirs; cap still stops when `Add` fails
- `staticShouldIgnorePath`: root-level system trees blocked; in-project same-named subdirs (`Library/`, `System/`) and external disks (`/Volumes`) not blocked

## Verification

`go build ./...`, `go vet`, and `go test -race ./internal/sensor/git/` all green.