### PR TITLE
feat(relay): cross-agent driver↔reviewer auto-handoff

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -239,6 +239,42 @@ column lists + sample queries that get published with the skill.
 | `TMA1_DEBUG_POSTTOOLUSE` | (unset) | Set to `1` to emit a debug marker on every PostToolUse hook regardless of anomalies. Plumbing aid. |
 | `TMA1_CONTEXT_PRESSURE_THRESHOLD` | `100000` | Input-token threshold (whole-session sum) for the R-context-pressure anomaly. ≈ 50 % of CC Sonnet 4's 200 k context. |
 | `OPENCLAW_STATE_DIR` | `~/.openclaw` (with `~/.clawdbot` legacy fallback) | Override the OpenClaw session base directory the transcript scanner watches. |
+| `TMA1_RELAY_WAKE_TIMEOUT` | `10m` | How long the relay waits for a woken peer to hand back before nudging the originator's terminal. `0` disables the nudge. Go duration syntax. |
+| `TMA1_RELAY_BRACKETED_PASTE` | `1` | iTerm waker wraps multi-line prompts in bracketed-paste markers so the REPL takes them as one block. Set `0` to fall back to single-line injection (collapse newlines) for a REPL that doesn't honour `ESC[?2004h`. |
+| `TMA1_RELAY_ITERM_BUSY_GATE` | `1` | iTerm waker skips injection (returns busy, no worker fallback) when the target session `is processing`. Set `0` to inject regardless. |
+| `TMA1_OSASCRIPT_PATH` / `TMA1_TMUX_PATH` / `TMA1_CODEX_PATH` / `TMA1_CLAUDE_PATH` | (LookPath) | Override the resolved binary for a waker when launchd's narrow PATH can't find it. |
+
+## Relay handoff (`internal/relay`)
+
+Cross-agent driver↔reviewer auto-handoff. At a milestone the driver/reviewer
+calls the `tma1_handoff` MCP tool → `POST /api/relay/signal` (token-gated) →
+the `Coordinator` looks up the transition, resolves the counterpart's
+registered terminal, and a `Waker` injects the next instruction (with the
+peer's summary inline).
+
+- **Wakers**, tried in reliability order (`Registry`): `tmux` (pane-precise,
+  `set-buffer` + `paste-buffer -p` bracketed paste + `Enter`) → `iterm`
+  (osascript locates the session by its `ITERM_SESSION_ID` UUID, injects via
+  `write text … newline no` + a submit Enter; the prompt is passed as
+  osascript **argv**, never interpolated into the AppleScript source) →
+  `worker` (universal headless fallback: `codex exec` / `claude -p`, detached).
+  A busy iTerm session stops the chain (no duplicate worker); a dead/closed
+  session id falls through.
+- **Terminal registry**: hook scripts report `X-Tma1-Role` +
+  `X-Tma1-Terminal` (`tmux=$TMUX_PANE;iterm=$ITERM_SESSION_ID;…`) on every
+  event. `SessionStart` registers, `SessionEnd` unregisters, every other
+  event (including CC's per-turn `Stop`) refreshes `LastSeen`.
+- **Busy-debounce + timeout**: once a role is woken it's marked pending; a
+  re-signal to a still-pending role is dropped honestly (caller retries),
+  and if the peer never hands back within `TMA1_RELAY_WAKE_TIMEOUT` the
+  originator is nudged. Pending clears on the peer's own next signal or
+  `SessionEnd`.
+- **Configurable transitions**: an optional `~/.tma1/relay.json`
+  (`{"transitions":{"plan_ready":{"wake_role":"reviewer","prompt":"…"}}}`)
+  overrides the built-in 4-stage table; malformed → built-in defaults.
+- **macOS TCC**: the first osascript that controls iTerm triggers an
+  Automation-permission prompt. Under launchd (no GUI session) it fails
+  silently with `-1743` → the iterm waker surfaces it and falls through.
 
 ## Where to look
 

--- a/server/cmd/tma1-server/main.go
+++ b/server/cmd/tma1-server/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/tma1-ai/tma1/server/internal/install"
 	"github.com/tma1-ai/tma1/server/internal/mcp"
 	"github.com/tma1-ai/tma1/server/internal/perception"
+	"github.com/tma1-ai/tma1/server/internal/relay"
 	"github.com/tma1-ai/tma1/server/internal/sensor/build"
 	"github.com/tma1-ai/tma1/server/internal/transcript"
 )
@@ -496,11 +497,25 @@ func main() {
 		Provider: cfg.LLMProvider,
 		Model:    cfg.LLMModel,
 	}
+	// Relay coordinator: per-project driver/reviewer handoff. The token is
+	// shared with MCP children via installer-written env so only local
+	// agents holding it can POST /api/relay/signal (which injects terminal
+	// text / spawns workers — not something an Origin check can guard).
+	relayToken, rtErr := relay.LoadOrCreateToken(cfg.DataDir)
+	if rtErr != nil {
+		logger.Warn("relay token unavailable; handoff signal disabled", "err", rtErr)
+	}
+	relayCoord := relay.NewCoordinator(logger, relay.NewRegistry(
+		relay.NewTmuxWaker(logger),
+		relay.NewWorkerWaker(logger),
+	), perception.ResolveProjectRoot)
 	srv := handler.New(cfg.GreptimeDBHTTPPort, cfg.Port, webFileSystem(), logger, tw, bc, llmCfg, handler.ServerConfig{
 		DataDir:          cfg.DataDir,
 		DataTTL:          cfg.DataTTL,
 		QueryConcurrency: cfg.QueryConcurrency,
 		LogLevelVar:      &logLevel,
+		RelayCoordinator: relayCoord,
+		RelayToken:       relayToken,
 	})
 	bgCtx, bgCancel := context.WithCancel(context.Background())
 	defer bgCancel()
@@ -1003,6 +1018,12 @@ func runMCPServe() error {
 		mcp.ExternalChangesTool{Bundler: bundler},
 		mcp.ProjectStateTool{Bundler: bundler},
 		mcp.PeerSessionsTool{Bundler: bundler},
+		mcp.RelayHandoffTool{
+			Port:   cfg.Port,
+			Caller: os.Getenv("TMA1_MCP_CALLER"),
+			Role:   os.Getenv("TMA1_RELAY_ROLE"),
+			Token:  os.Getenv("TMA1_RELAY_TOKEN"),
+		},
 	)
 
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)

--- a/server/cmd/tma1-server/main.go
+++ b/server/cmd/tma1-server/main.go
@@ -505,10 +505,22 @@ func main() {
 	if rtErr != nil {
 		logger.Warn("relay token unavailable; handoff signal disabled", "err", rtErr)
 	}
+	// Waker reliability order: tmux (pane-precise) → iterm (visible wake for
+	// iTerm users not in tmux) → worker (universal headless fallback).
 	relayCoord := relay.NewCoordinator(logger, relay.NewRegistry(
 		relay.NewTmuxWaker(logger),
+		relay.NewItermWaker(logger),
 		relay.NewWorkerWaker(logger),
 	), perception.ResolveProjectRoot)
+	// Optional transition-table override (~/.tma1/relay.json); fall back to
+	// the built-in table when absent or malformed.
+	if t, err := relay.LoadTransitions(filepath.Join(cfg.DataDir, "relay.json")); err == nil {
+		relayCoord.SetTransitions(t)
+	} else if !os.IsNotExist(err) {
+		logger.Warn("relay.json invalid; using built-in transitions", "err", err)
+	}
+	relayCoord.SetWakeTimeout(relayWakeTimeout())
+	defer relayCoord.Stop()
 	srv := handler.New(cfg.GreptimeDBHTTPPort, cfg.Port, webFileSystem(), logger, tw, bc, llmCfg, handler.ServerConfig{
 		DataDir:          cfg.DataDir,
 		DataTTL:          cfg.DataTTL,
@@ -1042,6 +1054,20 @@ func readVersionFile(path string) string {
 
 func parsePort(s string) (int, error) {
 	return strconv.Atoi(s)
+}
+
+// relayWakeTimeout reads TMA1_RELAY_WAKE_TIMEOUT (a Go duration, e.g.
+// "10m"). Unset → 10m default; "0" disables the timeout nudge.
+func relayWakeTimeout() time.Duration {
+	v := os.Getenv("TMA1_RELAY_WAKE_TIMEOUT")
+	if v == "" {
+		return 10 * time.Minute
+	}
+	d, err := time.ParseDuration(v)
+	if err != nil {
+		return 10 * time.Minute
+	}
+	return d
 }
 
 func onUpgrade(httpPort int, logger *slog.Logger) error {

--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -17,6 +17,7 @@ import (
 	"github.com/go-chi/chi/v5/middleware"
 
 	"github.com/tma1-ai/tma1/server/internal/perception"
+	"github.com/tma1-ai/tma1/server/internal/relay"
 	"github.com/tma1-ai/tma1/server/internal/sensor/git"
 	"github.com/tma1-ai/tma1/server/internal/sensor/project"
 	"github.com/tma1-ai/tma1/server/internal/transcript"
@@ -50,6 +51,9 @@ type Server struct {
 	// settings changes take effect on next restart.
 	querySem    chan struct{}
 	logLevelVar *slog.LevelVar
+
+	relayCoordinator *relay.Coordinator
+	relayToken       string
 }
 
 // ServerConfig holds additional configuration for the Server.
@@ -58,6 +62,8 @@ type ServerConfig struct {
 	DataTTL          string
 	QueryConcurrency int
 	LogLevelVar      *slog.LevelVar
+	RelayCoordinator *relay.Coordinator
+	RelayToken       string
 }
 
 // New creates a new Server.
@@ -112,6 +118,8 @@ func New(greptimeHTTPPort int, tma1Port string, webFS http.FileSystem, logger *s
 		queryConcurrency:  qc,
 		querySem:          make(chan struct{}, qc),
 		logLevelVar:       sc.LogLevelVar,
+		relayCoordinator:  sc.RelayCoordinator,
+		relayToken:        sc.RelayToken,
 	}
 	// Route Detector emit-log INSERTs through the same semaphore so
 	// hook handlers and anomaly emits share a single capacity budget
@@ -177,6 +185,11 @@ func (s *Server) Router() http.Handler {
 	// Hook events from Claude Code / Codex.
 	r.Post("/api/hooks", s.handleHooks)
 	r.Get("/api/hooks/stream", s.handleHookStream)
+
+	// Relay handoff signal — wakes the peer agent's terminal at a
+	// workflow milestone. Token-authenticated (not origin-gated: the
+	// MCP-child caller is not a browser and sends no Origin).
+	r.Post("/api/relay/signal", s.handleRelaySignal)
 
 	// Anomalies aggregation for the dashboard's Anomalies tab.
 	r.Get("/api/anomalies", s.handleAnomaliesQuery)

--- a/server/internal/handler/hooks.go
+++ b/server/internal/handler/hooks.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/tma1-ai/tma1/server/internal/derive"
 	"github.com/tma1-ai/tma1/server/internal/perception"
+	"github.com/tma1-ai/tma1/server/internal/relay"
 	"github.com/tma1-ai/tma1/server/internal/sqlutil"
 	"github.com/tma1-ai/tma1/server/internal/strutil"
 )
@@ -206,6 +207,41 @@ func (s *Server) handleHooks(w http.ResponseWriter, r *http.Request) {
 	// CC has no such backstop parser; the gate is a no-op for it.
 	if agentSource == "codex" && payload.SessionID != "" {
 		codexLiveSessions.markLive(payload.SessionID)
+	}
+
+	// Relay: keep the per-project driver/reviewer terminal registry fresh
+	// so a handoff signal can wake the counterpart. Role + terminal
+	// identifiers ride in headers the hook script sets from the agent's
+	// own terminal env (TMUX_PANE, ITERM_SESSION_ID, ...) — tma1-server's
+	// own env is unrelated, so it can't read them itself. SessionStart
+	// registers; SessionEnd unregisters; every other event — INCLUDING
+	// Stop, which CC fires at every turn end (NOT just session end) —
+	// touches, refreshing LastSeen so an active session never ages out.
+	// Treating Stop as unregister would delete the driver right after it
+	// called tma1_handoff, breaking the second hop of the handoff.
+	if s.relayCoordinator != nil {
+		if role := r.Header.Get("X-Tma1-Role"); relay.ValidRole(role) {
+			switch payload.HookEventName {
+			case "SessionStart":
+				s.relayCoordinator.Register(relay.Target{
+					Role:      role,
+					SessionID: payload.SessionID,
+					Agent:     agentSource,
+					CWD:       payload.CWD,
+					Terminals: relay.ParseTerminals(r.Header.Get("X-Tma1-Terminal")),
+				})
+			case "SessionEnd":
+				s.relayCoordinator.Unregister(payload.CWD, role, payload.SessionID)
+			default:
+				s.relayCoordinator.Touch(relay.Target{
+					Role:      role,
+					SessionID: payload.SessionID,
+					Agent:     agentSource,
+					CWD:       payload.CWD,
+					Terminals: relay.ParseTerminals(r.Header.Get("X-Tma1-Terminal")),
+				})
+			}
+		}
 	}
 
 	// Normalize tool_response to string.

--- a/server/internal/handler/relay.go
+++ b/server/internal/handler/relay.go
@@ -1,0 +1,70 @@
+package handler
+
+import (
+	"crypto/subtle"
+	"encoding/json"
+	"io"
+	"net/http"
+
+	"github.com/tma1-ai/tma1/server/internal/relay"
+)
+
+const maxRelayBody = 64 << 10 // 64 KB — summary can be a few KB, leave headroom
+
+// relaySignalReq is the body the MCP tma1_handoff tool POSTs.
+type relaySignalReq struct {
+	Stage     string `json:"stage"`
+	Role      string `json:"role"`
+	CWD       string `json:"cwd"`
+	Summary   string `json:"summary"`
+	SessionID string `json:"session_id"`
+}
+
+// handleRelaySignal receives a milestone handoff from one agent's MCP
+// child and wakes the counterpart's terminal.
+//
+// Unlike the dashboard's origin-checked write routes, this endpoint
+// injects terminal text / spawns worker processes, so an Origin check
+// (which a non-browser caller doesn't send anyway) is the wrong guard.
+// It validates a shared local token instead. Validation errors return
+// 4xx — the "don't break the agent loop" concern is handled in the MCP
+// tool, which turns a non-2xx into a plain (non-error) tool result.
+func (s *Server) handleRelaySignal(w http.ResponseWriter, r *http.Request) {
+	if s.relayToken == "" ||
+		subtle.ConstantTimeCompare([]byte(r.Header.Get("X-Tma1-Relay-Token")), []byte(s.relayToken)) != 1 {
+		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "invalid relay token"})
+		return
+	}
+	if s.relayCoordinator == nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "relay not configured"})
+		return
+	}
+
+	body, err := io.ReadAll(io.LimitReader(r.Body, maxRelayBody))
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "read body"})
+		return
+	}
+	var req relaySignalReq
+	if err := json.Unmarshal(body, &req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "malformed json"})
+		return
+	}
+	if _, ok := relay.Lookup(req.Stage); !ok {
+		writeJSON(w, http.StatusBadRequest, map[string]any{
+			"error": "unknown stage", "valid_stages": relay.ValidStages(),
+		})
+		return
+	}
+	if !relay.ValidRole(req.Role) {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid role (want driver|reviewer)"})
+		return
+	}
+
+	res, err := s.relayCoordinator.Signal(r.Context(), req.Stage, req.Role, req.CWD, req.Summary)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusOK, res)
+}

--- a/server/internal/handler/relay.go
+++ b/server/internal/handler/relay.go
@@ -50,9 +50,9 @@ func (s *Server) handleRelaySignal(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "malformed json"})
 		return
 	}
-	if _, ok := relay.Lookup(req.Stage); !ok {
+	if !s.relayCoordinator.KnownStage(req.Stage) {
 		writeJSON(w, http.StatusBadRequest, map[string]any{
-			"error": "unknown stage", "valid_stages": relay.ValidStages(),
+			"error": "unknown stage", "valid_stages": s.relayCoordinator.ValidStages(),
 		})
 		return
 	}

--- a/server/internal/handler/relay_test.go
+++ b/server/internal/handler/relay_test.go
@@ -1,0 +1,90 @@
+package handler
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/tma1-ai/tma1/server/internal/relay"
+)
+
+func newRelayServer() *Server {
+	coord := relay.NewCoordinator(nil, relay.NewRegistry(), func(cwd string) string { return cwd })
+	return &Server{relayToken: "secret", relayCoordinator: coord}
+}
+
+func postSignal(t *testing.T, s *Server, token, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/api/relay/signal", strings.NewReader(body))
+	if token != "" {
+		req.Header.Set("X-Tma1-Relay-Token", token)
+	}
+	rec := httptest.NewRecorder()
+	s.handleRelaySignal(rec, req)
+	return rec
+}
+
+func TestRelaySignalAuth(t *testing.T) {
+	s := newRelayServer()
+	if rec := postSignal(t, s, "", `{"stage":"plan_ready","role":"driver"}`); rec.Code != http.StatusUnauthorized {
+		t.Fatalf("missing token: want 401, got %d", rec.Code)
+	}
+	if rec := postSignal(t, s, "wrong", `{"stage":"plan_ready","role":"driver"}`); rec.Code != http.StatusUnauthorized {
+		t.Fatalf("wrong token: want 401, got %d", rec.Code)
+	}
+}
+
+func TestRelaySignalValidation(t *testing.T) {
+	s := newRelayServer()
+	if rec := postSignal(t, s, "secret", `{bad json`); rec.Code != http.StatusBadRequest {
+		t.Fatalf("malformed body: want 400, got %d", rec.Code)
+	}
+	if rec := postSignal(t, s, "secret", `{"stage":"bogus","role":"driver"}`); rec.Code != http.StatusBadRequest {
+		t.Fatalf("unknown stage: want 400, got %d", rec.Code)
+	}
+	if rec := postSignal(t, s, "secret", `{"stage":"plan_ready","role":"nope"}`); rec.Code != http.StatusBadRequest {
+		t.Fatalf("invalid role: want 400, got %d", rec.Code)
+	}
+}
+
+func TestRelaySignalValidNoTarget(t *testing.T) {
+	s := newRelayServer()
+	rec := postSignal(t, s, "secret", `{"stage":"plan_ready","role":"driver","cwd":"/repo"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("valid signal: want 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), `"target_found":false`) {
+		t.Fatalf("want target_found=false (no reviewer registered), body=%s", rec.Body.String())
+	}
+}
+
+// postHook drives handleHooks with a minimal hook body + relay role header.
+// greptimeHTTPPort is 0 (test sentinel) so no DB writes happen.
+func postHook(s *Server, event, role, cwd, sessionID string) {
+	body := `{"hook_event_name":"` + event + `","session_id":"` + sessionID + `","cwd":"` + cwd + `"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/hooks", strings.NewReader(body))
+	req.Header.Set("X-Tma1-Role", role)
+	s.handleHooks(httptest.NewRecorder(), req)
+}
+
+// TestStopDoesNotUnregisterDriver locks the P1 fix: CC fires Stop at every
+// turn end, so Stop must refresh (Touch) the target, not delete it —
+// otherwise the driver vanishes the moment it calls tma1_handoff and the
+// reviewer can never wake it back. SessionEnd is the only unregister event.
+func TestStopDoesNotUnregisterDriver(t *testing.T) {
+	coord := relay.NewCoordinator(nil, relay.NewRegistry(), func(c string) string { return c })
+	s := &Server{relayCoordinator: coord} // greptimeHTTPPort 0 → no DB writes
+
+	postHook(s, "SessionStart", "driver", "/repo", "d1")
+	postHook(s, "Stop", "driver", "/repo", "d1") // turn end — must NOT remove the target
+	if res, _ := coord.Signal(context.Background(), relay.StagePlanReviewed, relay.RoleReviewer, "/repo", ""); !res.TargetFound {
+		t.Fatal("Stop must not unregister the driver (it fires at every turn end)")
+	}
+
+	postHook(s, "SessionEnd", "driver", "/repo", "d1") // real session end — removes
+	if res, _ := coord.Signal(context.Background(), relay.StagePlanReviewed, relay.RoleReviewer, "/repo", ""); res.TargetFound {
+		t.Fatal("SessionEnd should unregister the driver")
+	}
+}

--- a/server/internal/hooks/hooks.go
+++ b/server/internal/hooks/hooks.go
@@ -8,7 +8,10 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
+
+	"github.com/tma1-ai/tma1/server/internal/relay"
 )
 
 //go:embed tma1-hook.sh.tmpl
@@ -44,8 +47,9 @@ func EnsureHookScript(dataDir string, port int, logger *slog.Logger) (string, er
 
 // EnsureHookScriptFor writes the hook script for the requested adapter
 // to <dataDir>/hooks/. Unix gets a `.sh`, Windows gets a `.ps1`. The
-// content is the embedded template with `{{PORT}}` substituted.
-// Idempotent — the file is only rewritten if its content differs.
+// content is the embedded template with `{{PORT}}` and `{{ROLE}}`
+// substituted. Idempotent — the file is only rewritten if its content
+// differs.
 func EnsureHookScriptFor(adapter Adapter, dataDir string, port int, logger *slog.Logger) (string, error) {
 	dir := filepath.Join(dataDir, "hooks")
 	if err := os.MkdirAll(dir, 0o755); err != nil {
@@ -55,7 +59,43 @@ func EnsureHookScriptFor(adapter Adapter, dataDir string, port int, logger *slog
 	portStr := fmt.Sprintf("%d", port)
 	tmpl, name := selectHookTemplate(adapter)
 	content := strings.ReplaceAll(tmpl, "{{PORT}}", portStr)
+	content = strings.ReplaceAll(content, "{{ROLE}}", defaultRole(adapter))
 	return writeScript(filepath.Join(dir, name), content, logger)
+}
+
+// defaultRole maps an adapter to its relay role: Claude Code drives the
+// workflow (driver), Codex reviews (reviewer). Baked into the hook
+// script as the {{ROLE}} default and overridable at runtime via the
+// TMA1_RELAY_ROLE env in the agent's shell. Deriving from the adapter
+// (rather than an install flag) keeps the server-startup EnsureHookScript
+// and the installer writing identical script content for a given adapter,
+// so neither clobbers the other.
+func defaultRole(adapter Adapter) string {
+	if adapter == AdapterCodex {
+		return relay.RoleReviewer
+	}
+	return relay.RoleDriver
+}
+
+// relayEnv returns the MCP-child env entries the relay handoff tool needs:
+// the parent server port to POST signals to, the agent's role, and the
+// shared signal-auth token. Merged into each adapter's MCP server env.
+func relayEnv(dataDir string, port int, role string, dryRun bool) map[string]any {
+	env := map[string]any{
+		"TMA1_PORT":       strconv.Itoa(port),
+		"TMA1_RELAY_ROLE": role,
+	}
+	var tok string
+	if dryRun {
+		// Dry-run must not create the token file; only surface an existing one.
+		tok, _ = relay.LoadToken(dataDir)
+	} else if t, err := relay.LoadOrCreateToken(dataDir); err == nil {
+		tok = t
+	}
+	if tok != "" {
+		env["TMA1_RELAY_TOKEN"] = tok
+	}
+	return env
 }
 
 // HookScriptPath returns the CC hook script path EnsureHookScript

--- a/server/internal/hooks/install_cc.go
+++ b/server/internal/hooks/install_cc.go
@@ -115,7 +115,7 @@ func (i *ClaudeCodeInstaller) mkdirAll(path string, perm os.FileMode) error {
 // dryRun / getLogger satisfy the installSink interface so the helpers
 // in install_shared.go can route DryRun + structured logging through
 // this installer.
-func (i *ClaudeCodeInstaller) dryRun() bool          { return i.DryRun }
+func (i *ClaudeCodeInstaller) dryRun() bool            { return i.DryRun }
 func (i *ClaudeCodeInstaller) getLogger() *slog.Logger { return i.Logger }
 
 // Install performs all installation steps. Errors from any step are joined
@@ -340,6 +340,11 @@ func (i *ClaudeCodeInstaller) installMCPServer() (string, bool, error) {
 	// back to 14000 and return empty results.
 	if i.GreptimeDBHTTPPort != 0 && i.GreptimeDBHTTPPort != defaultGreptimeDBHTTPPort {
 		env["TMA1_GREPTIMEDB_HTTP_PORT"] = strconv.Itoa(i.GreptimeDBHTTPPort)
+	}
+	// Relay: parent port + role + signal token so the MCP child's
+	// tma1_handoff tool can reach /api/relay/signal.
+	for k, v := range relayEnv(i.DataDir, i.Port, "driver", i.DryRun) {
+		env[k] = v
 	}
 	desired["env"] = env
 

--- a/server/internal/hooks/install_codex.go
+++ b/server/internal/hooks/install_codex.go
@@ -63,12 +63,12 @@ type CodexInstaller struct {
 //   - PostToolUse       → injects per-tool anomaly notes (rare)
 //   - Stop              → blocks on unresolved HIGH-severity anomalies
 //   - PreToolUse        → telemetry-only; Codex does not consume
-//                         `additionalContext` from PreToolUse hooks
-//                         per developers.openai.com/codex/hooks +
-//                         openai/codex#19385. We still register it so
-//                         the anomaly rules that query
-//                         `event_type = 'PreToolUse'` (file edits,
-//                         Bash commands) get the event stream.
+//     `additionalContext` from PreToolUse hooks
+//     per developers.openai.com/codex/hooks +
+//     openai/codex#19385. We still register it so
+//     the anomaly rules that query
+//     `event_type = 'PreToolUse'` (file edits,
+//     Bash commands) get the event stream.
 //
 // PreCompact is deliberately NOT registered: it doesn't exist in
 // Codex's hook catalogue (SessionStart / PreToolUse / PermissionRequest
@@ -313,6 +313,11 @@ func (i *CodexInstaller) installMCPServer() (string, bool, error) {
 	// results.
 	if i.GreptimeDBHTTPPort != 0 && i.GreptimeDBHTTPPort != defaultGreptimeDBHTTPPort {
 		env["TMA1_GREPTIMEDB_HTTP_PORT"] = strconv.Itoa(i.GreptimeDBHTTPPort)
+	}
+	// Relay: parent port + role + signal token so the MCP child's
+	// tma1_handoff tool can reach /api/relay/signal.
+	for k, v := range relayEnv(i.DataDir, i.Port, "reviewer", i.DryRun) {
+		env[k] = v
 	}
 	desired["env"] = env
 

--- a/server/internal/hooks/tma1-hook-codex.ps1.tmpl
+++ b/server/internal/hooks/tma1-hook-codex.ps1.tmpl
@@ -6,6 +6,8 @@
 # Codex hook protocol: stdin = JSON object with snake_case keys. stdout =
 # JSON object. Empty stdout (or {}) is the silent-no-op signal.
 #
+# Relay headers: see tma1-hook.ps1.tmpl. Codex's baked role is "reviewer".
+#
 # Fail-safe: any error → empty stdout, exit 0. Never blocks the agent.
 # PowerShell's Invoke-WebRequest only accepts whole-second timeouts; we
 # trade ~500 ms of latency on Windows for keeping the script dependency-
@@ -13,9 +15,12 @@
 # 300 ms `hookInjectionTimeout` cap.
 $ErrorActionPreference = 'SilentlyContinue'
 $body = [Console]::In.ReadToEnd()
+$role = if ($env:TMA1_RELAY_ROLE) { $env:TMA1_RELAY_ROLE } else { '{{ROLE}}' }
+$term = "tmux=$($env:TMUX_PANE);iterm=$($env:ITERM_SESSION_ID);wezterm=$($env:WEZTERM_PANE);kitty=$($env:KITTY_LISTEN_ON)"
+$headers = @{ 'X-Tma1-Role' = $role; 'X-Tma1-Terminal' = $term }
 try {
     $resp = Invoke-WebRequest -Uri 'http://127.0.0.1:{{PORT}}/api/hooks?source=codex&envelope=codex' `
-        -Method POST -ContentType 'application/json' -Body $body -TimeoutSec 1 -UseBasicParsing
+        -Method POST -ContentType 'application/json' -Headers $headers -Body $body -TimeoutSec 1 -UseBasicParsing
     if ($resp.Content) { [Console]::Out.Write($resp.Content) }
 } catch {
     exit 0

--- a/server/internal/hooks/tma1-hook-codex.sh.tmpl
+++ b/server/internal/hooks/tma1-hook-codex.sh.tmpl
@@ -8,9 +8,15 @@
 # (session_id / hook_event_name / cwd / tool_name / …). stdout = JSON
 # object. Empty stdout (or {}) is the silent-no-op signal.
 #
+# Relay headers: see tma1-hook.sh.tmpl. Codex's baked role is "reviewer".
+#
 # Fail-safe: any error → empty stdout, exit 0. Never blocks the agent.
+TMA1_ROLE="${TMA1_RELAY_ROLE:-{{ROLE}}}"
+TMA1_TERM="tmux=${TMUX_PANE};iterm=${ITERM_SESSION_ID};wezterm=${WEZTERM_PANE};kitty=${KITTY_LISTEN_ON}"
 RESPONSE=$(curl -sf -m 0.5 -X POST \
   -H 'Content-Type: application/json' \
+  -H "X-Tma1-Role: ${TMA1_ROLE}" \
+  -H "X-Tma1-Terminal: ${TMA1_TERM}" \
   --data-binary @- \
   "http://127.0.0.1:{{PORT}}/api/hooks?source=codex&envelope=codex" 2>/dev/null) || exit 0
 printf '%s' "$RESPONSE"

--- a/server/internal/hooks/tma1-hook.ps1.tmpl
+++ b/server/internal/hooks/tma1-hook.ps1.tmpl
@@ -3,12 +3,19 @@
 # Reads JSON from stdin, POSTs to localhost. The response body (which may be
 # empty) is written to stdout so Claude Code can use it as injection content.
 #
+# Relay headers: the script runs in the agent's terminal, so it can read the
+# terminal identifiers tma1-server can't see from its own env. Unset env vars
+# interpolate to empty and the server drops empty terminal values.
+#
 # Fail-safe: any error → empty stdout, exit 0. Never blocks the agent.
 $ErrorActionPreference = 'SilentlyContinue'
 $body = [Console]::In.ReadToEnd()
+$role = if ($env:TMA1_RELAY_ROLE) { $env:TMA1_RELAY_ROLE } else { '{{ROLE}}' }
+$term = "tmux=$($env:TMUX_PANE);iterm=$($env:ITERM_SESSION_ID);wezterm=$($env:WEZTERM_PANE);kitty=$($env:KITTY_LISTEN_ON)"
+$headers = @{ 'X-Tma1-Role' = $role; 'X-Tma1-Terminal' = $term }
 try {
     $resp = Invoke-WebRequest -Uri 'http://127.0.0.1:{{PORT}}/api/hooks' `
-        -Method POST -ContentType 'application/json' -Body $body -TimeoutSec 1 -UseBasicParsing
+        -Method POST -ContentType 'application/json' -Headers $headers -Body $body -TimeoutSec 1 -UseBasicParsing
     if ($resp.Content) { [Console]::Out.Write($resp.Content) }
 } catch {
     exit 0

--- a/server/internal/hooks/tma1-hook.sh.tmpl
+++ b/server/internal/hooks/tma1-hook.sh.tmpl
@@ -5,9 +5,18 @@
 # empty) is written to stdout so Claude Code can use it as injection content
 # (UserPromptSubmit prepend, PostToolUse append, etc).
 #
+# Relay headers: the script runs in the agent's terminal, so it can read the
+# terminal identifiers (TMUX_PANE, ITERM_SESSION_ID, ...) that tma1-server
+# can't see from its own env. X-Tma1-Role defaults to the adapter's baked
+# role and is overridable via TMA1_RELAY_ROLE in the agent's shell.
+#
 # Fail-safe: any error → empty stdout, exit 0. Never blocks the agent.
+TMA1_ROLE="${TMA1_RELAY_ROLE:-{{ROLE}}}"
+TMA1_TERM="tmux=${TMUX_PANE};iterm=${ITERM_SESSION_ID};wezterm=${WEZTERM_PANE};kitty=${KITTY_LISTEN_ON}"
 RESPONSE=$(curl -sf -m 0.5 -X POST \
   -H 'Content-Type: application/json' \
+  -H "X-Tma1-Role: ${TMA1_ROLE}" \
+  -H "X-Tma1-Terminal: ${TMA1_TERM}" \
   --data-binary @- \
   "http://127.0.0.1:{{PORT}}/api/hooks" 2>/dev/null) || exit 0
 printf '%s' "$RESPONSE"

--- a/server/internal/mcp/relay_tool.go
+++ b/server/internal/mcp/relay_tool.go
@@ -1,0 +1,119 @@
+package mcp
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/tma1-ai/tma1/server/internal/strutil"
+)
+
+// RelayHandoffTool lets an agent hand off to its peer at a workflow
+// milestone. It POSTs to the parent tma1-server's /api/relay/signal,
+// which wakes the counterpart terminal (driver↔reviewer).
+//
+// It runs in the mcp-serve child, which inherits the agent's cwd and the
+// env the installer wrote (TMA1_PORT / TMA1_RELAY_ROLE / TMA1_RELAY_TOKEN).
+type RelayHandoffTool struct {
+	Port   string // parent tma1-server HTTP port (TMA1_PORT)
+	Caller string // TMA1_MCP_CALLER: claude_code | codex
+	Role   string // TMA1_RELAY_ROLE: driver | reviewer (may be empty → derived from Caller)
+	Token  string // TMA1_RELAY_TOKEN: shared secret for /api/relay/signal
+	Client *http.Client
+}
+
+func (t RelayHandoffTool) Definition() Tool {
+	return Tool{
+		Name: "tma1_handoff",
+		Description: "Hand off to your peer agent at a workflow milestone, waking " +
+			"their terminal with an instruction to continue. Stages: " +
+			"plan_ready (driver→reviewer), plan_reviewed (reviewer→driver), " +
+			"impl_done (driver→reviewer), code_reviewed (reviewer→driver). " +
+			"Pass `summary` with your graded findings / conclusion so the peer " +
+			"sees it inline and need not re-pull your whole session.",
+		InputSchema: InputSchema{
+			Type: "object",
+			Properties: map[string]Property{
+				"stage": {
+					Type:        "string",
+					Description: "Milestone: plan_ready | plan_reviewed | impl_done | code_reviewed.",
+				},
+				"summary": {
+					Type:        "string",
+					Description: "Your conclusion / graded findings, shown inline to the peer. Optional but strongly recommended.",
+				},
+			},
+			Required: []string{"stage"},
+		},
+	}
+}
+
+func (t RelayHandoffTool) Call(ctx context.Context, args map[string]any) (CallToolResult, error) {
+	stage, _ := args["stage"].(string)
+	if stage == "" {
+		return errorResult("stage is required (plan_ready | plan_reviewed | impl_done | code_reviewed)"), nil
+	}
+	summary, _ := args["summary"].(string)
+	// Bound the summary so the POST body always stays well under the
+	// server's relay-body limit. An oversized summary would otherwise get
+	// truncated mid-JSON by the server's LimitReader, fail to parse, and
+	// drop the handoff with only a vague "not delivered" to the agent.
+	summary = strutil.SafeTruncate(summary, 32<<10)
+
+	role := t.Role
+	if role == "" {
+		// Derive from the calling agent when the installer didn't set a role.
+		if t.Caller == "codex" {
+			role = "reviewer"
+		} else {
+			role = "driver"
+		}
+	}
+
+	cwd, _ := os.Getwd()
+	port := t.Port
+	if port == "" {
+		port = "14318"
+	}
+
+	body, _ := json.Marshal(map[string]string{
+		"stage": stage, "role": role, "cwd": cwd, "summary": summary,
+	})
+	url := fmt.Sprintf("http://127.0.0.1:%s/api/relay/signal", port)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return noteResult("handoff failed: " + err.Error()), nil
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Tma1-Relay-Token", t.Token)
+
+	client := t.Client
+	if client == nil {
+		client = &http.Client{Timeout: 2 * time.Second}
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		// Don't break the agent loop — surface as a plain (non-error) note.
+		return noteResult("handoff not delivered: " + err.Error()), nil
+	}
+	defer resp.Body.Close()
+	rb, _ := io.ReadAll(io.LimitReader(resp.Body, 8192))
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return noteResult(fmt.Sprintf("handoff not delivered (HTTP %d): %s", resp.StatusCode, string(rb))), nil
+	}
+	return noteResult("handoff delivered: " + string(rb)), nil
+}
+
+// noteResult returns a non-error tool result carrying an informational
+// message. The relay handoff intentionally never returns IsError so a
+// transient signal failure doesn't interrupt the agent's loop.
+func noteResult(msg string) CallToolResult {
+	return CallToolResult{Content: []ContentBlock{{Type: "text", Text: msg}}}
+}

--- a/server/internal/mcp/relay_tool_test.go
+++ b/server/internal/mcp/relay_tool_test.go
@@ -1,0 +1,85 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestRelayHandoffDefinition(t *testing.T) {
+	def := RelayHandoffTool{}.Definition()
+	if def.Name != "tma1_handoff" {
+		t.Fatalf("name = %q", def.Name)
+	}
+	if len(def.InputSchema.Required) != 1 || def.InputSchema.Required[0] != "stage" {
+		t.Fatalf("required = %v, want [stage]", def.InputSchema.Required)
+	}
+}
+
+func TestRelayHandoffEmptyStage(t *testing.T) {
+	res, err := RelayHandoffTool{}.Call(context.Background(), map[string]any{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.IsError {
+		t.Fatal("empty stage should yield an error result")
+	}
+}
+
+func TestRelayHandoffPostsBodyAndToken(t *testing.T) {
+	var gotBody map[string]string
+	var gotToken string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotToken = r.Header.Get("X-Tma1-Relay-Token")
+		b, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(b, &gotBody)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"dispatched":true}`))
+	}))
+	defer srv.Close()
+
+	port := strings.TrimPrefix(srv.URL, "http://127.0.0.1:")
+	tool := RelayHandoffTool{Port: port, Caller: "codex", Token: "tk", Client: srv.Client()}
+
+	res, err := tool.Call(context.Background(), map[string]any{"stage": "plan_reviewed", "summary": "S"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.IsError {
+		t.Fatalf("unexpected error result: %+v", res)
+	}
+	if gotToken != "tk" {
+		t.Fatalf("token header = %q, want tk", gotToken)
+	}
+	// Empty Role falls back to reviewer for a codex caller.
+	if gotBody["stage"] != "plan_reviewed" || gotBody["role"] != "reviewer" || gotBody["summary"] != "S" {
+		t.Fatalf("posted body = %+v", gotBody)
+	}
+}
+
+func TestRelayHandoffNon2xxIsNotError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":"invalid relay token"}`))
+	}))
+	defer srv.Close()
+
+	port := strings.TrimPrefix(srv.URL, "http://127.0.0.1:")
+	tool := RelayHandoffTool{Port: port, Caller: "claude_code", Token: "x", Client: srv.Client()}
+
+	res, err := tool.Call(context.Background(), map[string]any{"stage": "plan_ready"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// A non-2xx must NOT break the agent loop — surfaced as a plain note.
+	if res.IsError {
+		t.Fatal("non-2xx should be a plain (non-error) result")
+	}
+	if !strings.Contains(res.Content[0].Text, "not delivered") {
+		t.Fatalf("want 'not delivered' note, got %q", res.Content[0].Text)
+	}
+}

--- a/server/internal/relay/config.go
+++ b/server/internal/relay/config.go
@@ -1,0 +1,62 @@
+package relay
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"text/template"
+)
+
+// transitionConfig is the on-disk shape of an optional relay.json that
+// overrides the built-in transition table. Absent file → built-in
+// defaults; a malformed file is reported so the caller can fall back.
+type transitionConfig struct {
+	Transitions map[string]struct {
+		WakeRole string `json:"wake_role"`
+		Prompt   string `json:"prompt"`
+	} `json:"transitions"`
+}
+
+// DefaultTransitions returns a copy of the built-in transition table so a
+// Coordinator can own (and optionally replace) its map without mutating
+// package state.
+func DefaultTransitions() map[string]Transition {
+	out := make(map[string]Transition, len(transitions))
+	for k, v := range transitions {
+		out[k] = v
+	}
+	return out
+}
+
+// LoadTransitions reads an override table from path. The caller should
+// treat os.IsNotExist specially (use DefaultTransitions). Every prompt is
+// parsed as a template up front so a typo fails loudly at load instead of
+// at the first handoff.
+func LoadTransitions(path string) (map[string]Transition, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var cfg transitionConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+	if len(cfg.Transitions) == 0 {
+		return nil, fmt.Errorf("%s: no transitions defined", path)
+	}
+	// Merge overrides ONTO the built-in defaults so a partial relay.json
+	// (e.g. customising only plan_ready) keeps the other stages working
+	// instead of dropping them from the table.
+	out := DefaultTransitions()
+	for stage, t := range cfg.Transitions {
+		if !ValidRole(t.WakeRole) {
+			return nil, fmt.Errorf("stage %q: invalid wake_role %q", stage, t.WakeRole)
+		}
+		tmpl, err := template.New(stage).Parse(t.Prompt)
+		if err != nil {
+			return nil, fmt.Errorf("stage %q: %w", stage, err)
+		}
+		out[stage] = Transition{WakeRole: t.WakeRole, promptTmpl: tmpl}
+	}
+	return out, nil
+}

--- a/server/internal/relay/config_test.go
+++ b/server/internal/relay/config_test.go
@@ -1,0 +1,64 @@
+package relay
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadTransitionsMissing(t *testing.T) {
+	_, err := LoadTransitions(filepath.Join(t.TempDir(), "absent.json"))
+	if !os.IsNotExist(err) {
+		t.Fatalf("absent file should surface os.IsNotExist, got %v", err)
+	}
+}
+
+func TestLoadTransitionsOverride(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "relay.json")
+	js := `{"transitions":{"plan_ready":{"wake_role":"reviewer","prompt":"custom {{.Project}} review"}}}`
+	if err := os.WriteFile(path, []byte(js), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	tbl, err := LoadTransitions(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tr, ok := tbl[StagePlanReady]
+	if !ok || tr.WakeRole != RoleReviewer {
+		t.Fatalf("override not loaded: %+v", tbl)
+	}
+	out, err := renderPrompt(tr, promptData{Project: "p"})
+	if err != nil || out != "custom p review" {
+		t.Fatalf("rendered=%q err=%v", out, err)
+	}
+}
+
+func TestLoadTransitionsRejectsBadRoleAndTemplate(t *testing.T) {
+	dir := t.TempDir()
+	bad := map[string]string{
+		"badrole.json": `{"transitions":{"plan_ready":{"wake_role":"nobody","prompt":"x"}}}`,
+		"badtmpl.json": `{"transitions":{"plan_ready":{"wake_role":"reviewer","prompt":"{{.Oops"}}}`,
+		"empty.json":   `{"transitions":{}}`,
+	}
+	for name, js := range bad {
+		path := filepath.Join(dir, name)
+		if err := os.WriteFile(path, []byte(js), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := LoadTransitions(path); err == nil {
+			t.Fatalf("%s should fail to load", name)
+		}
+	}
+}
+
+func TestSetTransitionsUsedBySignal(t *testing.T) {
+	fw := &fakeWaker{name: "fake", can: true}
+	c := newTestCoord(NewRegistry(fw))
+	c.SetTransitions(DefaultTransitions()) // exercises the setter path
+	c.Register(Target{Role: RoleReviewer, SessionID: "r1", CWD: "/repo"})
+	if res, _ := c.Signal(context.Background(), StagePlanReady, RoleDriver, "/repo", "s"); !res.Dispatched {
+		t.Fatal("signal should dispatch with default transitions set")
+	}
+}

--- a/server/internal/relay/coordinator.go
+++ b/server/internal/relay/coordinator.go
@@ -2,8 +2,12 @@ package relay
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"log/slog"
+	"sort"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -33,23 +37,112 @@ type projectState struct {
 	reviewer *Target
 }
 
+// pendingWake records that we woke a role and are waiting for it to hand
+// back (its own next signal). It powers busy-debounce (don't re-wake a
+// role we're still waiting on) and the wake-timeout (nudge the originator
+// if the peer never responds).
+type pendingWake struct {
+	id         uint64 // identifies this reservation across cancel/arm races
+	originator string // the role to nudge on timeout
+	stage      string
+	since      time.Time
+	timer      *time.Timer
+}
+
+// pendingSeq tags each reservation so cancel/arm act only on their own.
+var pendingSeq atomic.Uint64
+
 // Coordinator holds per-project driver/reviewer registration and routes
 // milestone signals to wake the counterpart's terminal.
 type Coordinator struct {
-	mu         sync.Mutex
-	projects   map[string]*projectState
-	waker      *Registry
-	projectKey func(string) string // injected (perception.ResolveProjectRoot) to avoid a package dependency
-	logger     *slog.Logger
-	nextGC     time.Time
+	mu          sync.Mutex
+	projects    map[string]*projectState
+	pending     map[string]*pendingWake // key = pendKey(project, wokeRole)
+	waker       *Registry
+	transitions map[string]Transition
+	wakeTimeout time.Duration // 0 disables the timeout nudge
+	stopped     bool
+	projectKey  func(string) string // injected (perception.ResolveProjectRoot) to avoid a package dependency
+	logger      *slog.Logger
+	nextGC      time.Time
 }
 
 func NewCoordinator(logger *slog.Logger, waker *Registry, projectKey func(string) string) *Coordinator {
 	return &Coordinator{
-		projects:   make(map[string]*projectState),
-		waker:      waker,
-		projectKey: projectKey,
-		logger:     logger,
+		projects:    make(map[string]*projectState),
+		pending:     make(map[string]*pendingWake),
+		waker:       waker,
+		transitions: DefaultTransitions(),
+		projectKey:  projectKey,
+		logger:      logger,
+	}
+}
+
+// SetTransitions replaces the transition table (e.g. loaded from
+// relay.json). Call before the Coordinator starts handling signals.
+func (c *Coordinator) SetTransitions(t map[string]Transition) {
+	if len(t) == 0 {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.transitions = t
+}
+
+// SetWakeTimeout sets how long to wait for a woken peer to hand back
+// before nudging the originator. Zero disables the nudge.
+func (c *Coordinator) SetWakeTimeout(d time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.wakeTimeout = d
+}
+
+// KnownStage reports whether the (possibly overridden) transition table
+// has this stage. The HTTP handler uses it so validation matches what
+// Signal will actually accept, instead of the package-level default table.
+func (c *Coordinator) KnownStage(stage string) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	_, ok := c.transitions[stage]
+	return ok
+}
+
+// ValidStages returns the sorted stages the live table accepts.
+func (c *Coordinator) ValidStages() []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]string, 0, len(c.transitions))
+	for k := range c.transitions {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func pendKey(project, role string) string { return project + "|" + role }
+
+// clearPendingLocked cancels and removes a role's pending wake. Caller
+// must hold c.mu.
+func (c *Coordinator) clearPendingLocked(project, role string) {
+	k := pendKey(project, role)
+	if pw := c.pending[k]; pw != nil {
+		if pw.timer != nil {
+			pw.timer.Stop()
+		}
+		delete(c.pending, k)
+	}
+}
+
+// Stop cancels all outstanding timeout timers. Called on server shutdown.
+func (c *Coordinator) Stop() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.stopped = true
+	for k, pw := range c.pending {
+		if pw.timer != nil {
+			pw.timer.Stop()
+		}
+		delete(c.pending, k)
 	}
 }
 
@@ -82,6 +175,15 @@ func (c *Coordinator) Register(t Target) {
 	key := c.key(t.CWD)
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	// A brand-new session for this role means whatever we previously woke is
+	// gone — clear any stale pending so it doesn't block future handoffs.
+	// This matters when the prior agent crashed without SessionEnd and the
+	// wake-timeout is disabled (otherwise the timeout would self-heal).
+	if ps := c.projects[key]; ps != nil {
+		if slot := roleSlot(ps, t.Role); slot != nil && *slot != nil && (*slot).SessionID != t.SessionID {
+			c.clearPendingLocked(key, t.Role)
+		}
+	}
 	c.upsertLocked(key, t)
 	c.gcLocked(time.Now())
 }
@@ -134,6 +236,7 @@ func (c *Coordinator) Unregister(cwd, role, sessionID string) {
 		return
 	}
 	*slot = nil
+	c.clearPendingLocked(key, role)
 	if ps.driver == nil && ps.reviewer == nil {
 		delete(c.projects, key)
 	}
@@ -155,19 +258,36 @@ func (c *Coordinator) upsertLocked(key string, t Target) {
 // across it would stall all other Register/Touch/Signal calls).
 func (c *Coordinator) Signal(ctx context.Context, stage, fromRole, cwd, summary string) (SignalResult, error) {
 	res := SignalResult{Stage: stage}
-	tr, ok := Lookup(stage)
+	key := c.key(cwd)
+
+	c.mu.Lock()
+	tr, ok := c.transitions[stage]
 	if !ok {
+		c.mu.Unlock()
 		res.Note = "unknown stage"
 		return res, nil
 	}
 	res.WokeRole = tr.WakeRole
 	if tr.WakeRole == fromRole {
+		c.mu.Unlock()
 		res.Note = "transition would wake the sender — misconfigured stage/role"
 		return res, nil
 	}
 
-	key := c.key(cwd)
-	c.mu.Lock()
+	// The sender handing off means it finished the task it was woken for —
+	// clear any pending wake we were tracking for it (and its timeout).
+	c.clearPendingLocked(key, fromRole)
+
+	// Busy-debounce: if we already woke the target role and it hasn't
+	// handed back yet, don't re-wake it — drop honestly and tell the
+	// caller to retry once the peer is free.
+	if pw := c.pending[pendKey(key, tr.WakeRole)]; pw != nil {
+		c.mu.Unlock()
+		res.Note = fmt.Sprintf("dropped: %s busy since %s (stage %s) — re-call tma1_handoff once it's free",
+			tr.WakeRole, pw.since.Format(time.Kitchen), pw.stage)
+		return res, nil
+	}
+
 	var target *Target
 	if ps := c.projects[key]; ps != nil {
 		if slot := roleSlot(ps, tr.WakeRole); slot != nil && *slot != nil {
@@ -175,30 +295,47 @@ func (c *Coordinator) Signal(ctx context.Context, stage, fromRole, cwd, summary 
 			target = &tc
 		}
 	}
-	c.mu.Unlock()
-
 	if target == nil {
+		c.mu.Unlock()
 		res.Note = "no " + tr.WakeRole + " registered for this project"
 		return res, nil
 	}
 	res.TargetFound = true
+
+	// Reserve the pending slot UNDER the lock, before releasing it to Wake.
+	// Without this, two concurrent signals would both pass the busy check
+	// above and double-wake the target (or spawn two workers). The reserved
+	// entry has no timer yet — the timer is armed only after a successful
+	// Wake (armReservation), and the reservation is cancelled if Wake fails.
+	resID := pendingSeq.Add(1)
+	c.pending[pendKey(key, tr.WakeRole)] = &pendingWake{
+		id: resID, originator: fromRole, stage: stage, since: time.Now(),
+	}
+	c.mu.Unlock()
 
 	if summary == "" {
 		summary = "(no summary provided — call get_peer_sessions to read the peer's full output)"
 	}
 	prompt, err := renderPrompt(tr, promptData{Project: key, FromRole: fromRole, Summary: summary})
 	if err != nil {
+		c.cancelReservation(key, tr.WakeRole, resID)
 		res.Note = "render prompt: " + err.Error()
 		return res, err
 	}
 
 	name, err := c.waker.WakeWith(ctx, *target, prompt)
 	if err != nil {
-		res.Note = "wake failed: " + err.Error()
+		c.cancelReservation(key, tr.WakeRole, resID)
+		if errors.Is(err, errTargetBusy) {
+			res.Note = "dropped: " + tr.WakeRole + " terminal busy — re-call tma1_handoff once it's free"
+		} else {
+			res.Note = "wake failed: " + err.Error()
+		}
 		return res, nil
 	}
 	res.WakerName = name
 	res.Dispatched = true
+	c.armReservation(key, tr.WakeRole, resID)
 	if name == "worker" {
 		// The worker fallback spawns a fresh non-interactive agent; whether
 		// its hooks/MCP fire to continue the relay chain is not yet
@@ -207,6 +344,74 @@ func (c *Coordinator) Signal(ctx context.Context, stage, fromRole, cwd, summary 
 		res.Note = "worker fallback started; hook/MCP continuation is best-effort (not yet spike-verified)"
 	}
 	return res, nil
+}
+
+// cancelReservation removes a pending reservation iff it's still the one we
+// made (id match), so a failed Wake doesn't evict a newer reservation.
+func (c *Coordinator) cancelReservation(project, role string, id uint64) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	k := pendKey(project, role)
+	if pw := c.pending[k]; pw != nil && pw.id == id {
+		if pw.timer != nil {
+			pw.timer.Stop()
+		}
+		delete(c.pending, k)
+	}
+}
+
+// armReservation attaches the timeout timer to our reservation after a
+// successful Wake — but only if it's still present and unchanged (a very
+// fast hand-back could have already cleared it). No-op after Stop.
+func (c *Coordinator) armReservation(project, role string, id uint64) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.stopped {
+		return
+	}
+	pw := c.pending[pendKey(project, role)]
+	if pw == nil || pw.id != id || pw.timer != nil {
+		return
+	}
+	if c.wakeTimeout > 0 {
+		pw.timer = time.AfterFunc(c.wakeTimeout, func() {
+			c.onWakeTimeout(project, role)
+		})
+	}
+}
+
+// onWakeTimeout fires when a woken peer hasn't handed back in time. It
+// nudges the originator's terminal. The lock is released before calling
+// the Waker (Wake may block).
+func (c *Coordinator) onWakeTimeout(project, wokeRole string) {
+	c.mu.Lock()
+	k := pendKey(project, wokeRole)
+	pw := c.pending[k]
+	if pw == nil { // already cleared by a hand-back / unregister
+		c.mu.Unlock()
+		return
+	}
+	delete(c.pending, k)
+	stage := pw.stage
+	originator := pw.originator
+	timeout := c.wakeTimeout // read mutex-guarded field under the lock
+	var target *Target
+	if ps := c.projects[project]; ps != nil {
+		if slot := roleSlot(ps, originator); slot != nil && *slot != nil {
+			tc := **slot
+			target = &tc
+		}
+	}
+	c.mu.Unlock()
+
+	if target == nil {
+		return
+	}
+	prompt := fmt.Sprintf("No response from the %s on your %q handoff after %s. "+
+		"Check on the peer terminal or follow up manually.", wokeRole, stage, timeout)
+	if _, err := c.waker.WakeWith(context.Background(), *target, prompt); err != nil && c.logger != nil {
+		c.logger.Warn("relay wake-timeout nudge failed", "project", project, "role", originator, "err", err)
+	}
 }
 
 // gcLocked reaps abandoned targets. Caller must hold c.mu.
@@ -218,9 +423,11 @@ func (c *Coordinator) gcLocked(now time.Time) {
 	for k, ps := range c.projects {
 		if ps.driver != nil && ps.driver.LastSeen.Before(cutoff) {
 			ps.driver = nil
+			c.clearPendingLocked(k, RoleDriver)
 		}
 		if ps.reviewer != nil && ps.reviewer.LastSeen.Before(cutoff) {
 			ps.reviewer = nil
+			c.clearPendingLocked(k, RoleReviewer)
 		}
 		if ps.driver == nil && ps.reviewer == nil {
 			delete(c.projects, k)

--- a/server/internal/relay/coordinator.go
+++ b/server/internal/relay/coordinator.go
@@ -1,0 +1,230 @@
+package relay
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+)
+
+const (
+	// staleAfter is a GC backstop for sessions that crashed without
+	// sending Stop/SessionEnd. Active sessions keep their LastSeen fresh
+	// via Touch on every hook, so a long-running session is never GC'd —
+	// this only reaps abandoned entries.
+	staleAfter = 12 * time.Hour
+	gcInterval = 30 * time.Minute
+)
+
+// SignalResult describes what a Signal call did, echoed back to the
+// calling agent so it sees confirmation ("woke reviewer via tmux") or a
+// reason nothing happened.
+type SignalResult struct {
+	Stage       string `json:"stage"`
+	WokeRole    string `json:"woke_role,omitempty"`
+	WakerName   string `json:"waker,omitempty"`
+	TargetFound bool   `json:"target_found"`
+	Dispatched  bool   `json:"dispatched"`
+	Note        string `json:"note,omitempty"`
+}
+
+type projectState struct {
+	driver   *Target
+	reviewer *Target
+}
+
+// Coordinator holds per-project driver/reviewer registration and routes
+// milestone signals to wake the counterpart's terminal.
+type Coordinator struct {
+	mu         sync.Mutex
+	projects   map[string]*projectState
+	waker      *Registry
+	projectKey func(string) string // injected (perception.ResolveProjectRoot) to avoid a package dependency
+	logger     *slog.Logger
+	nextGC     time.Time
+}
+
+func NewCoordinator(logger *slog.Logger, waker *Registry, projectKey func(string) string) *Coordinator {
+	return &Coordinator{
+		projects:   make(map[string]*projectState),
+		waker:      waker,
+		projectKey: projectKey,
+		logger:     logger,
+	}
+}
+
+func (c *Coordinator) key(cwd string) string {
+	if c.projectKey == nil {
+		return cwd
+	}
+	return c.projectKey(cwd)
+}
+
+func roleSlot(ps *projectState, role string) **Target {
+	switch role {
+	case RoleDriver:
+		return &ps.driver
+	case RoleReviewer:
+		return &ps.reviewer
+	}
+	return nil
+}
+
+// Register records (or replaces) the terminal for a role in a project.
+// Called on SessionStart.
+func (c *Coordinator) Register(t Target) {
+	if !ValidRole(t.Role) {
+		return
+	}
+	if t.LastSeen.IsZero() {
+		t.LastSeen = time.Now()
+	}
+	key := c.key(t.CWD)
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.upsertLocked(key, t)
+	c.gcLocked(time.Now())
+}
+
+// Touch refreshes LastSeen for the role's active session so a
+// long-running session never ages out. If the target is missing or
+// belongs to a different session, it (re)registers from t — covering the
+// case where the server started after the agent's SessionStart.
+func (c *Coordinator) Touch(t Target) {
+	if !ValidRole(t.Role) {
+		return
+	}
+	now := time.Now()
+	key := c.key(t.CWD)
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if ps := c.projects[key]; ps != nil {
+		if slot := roleSlot(ps, t.Role); slot != nil && *slot != nil && (*slot).SessionID == t.SessionID {
+			(*slot).LastSeen = now
+			c.gcLocked(now)
+			return
+		}
+	}
+	if t.LastSeen.IsZero() {
+		t.LastSeen = now
+	}
+	c.upsertLocked(key, t)
+	c.gcLocked(now)
+}
+
+// Unregister removes the role's target on Stop/SessionEnd. It only
+// removes when the session id matches (or none given), so a delayed Stop
+// from a prior session can't evict a freshly registered one.
+func (c *Coordinator) Unregister(cwd, role, sessionID string) {
+	if !ValidRole(role) {
+		return
+	}
+	key := c.key(cwd)
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	ps := c.projects[key]
+	if ps == nil {
+		return
+	}
+	slot := roleSlot(ps, role)
+	if slot == nil || *slot == nil {
+		return
+	}
+	if sessionID != "" && (*slot).SessionID != sessionID {
+		return
+	}
+	*slot = nil
+	if ps.driver == nil && ps.reviewer == nil {
+		delete(c.projects, key)
+	}
+}
+
+func (c *Coordinator) upsertLocked(key string, t Target) {
+	ps := c.projects[key]
+	if ps == nil {
+		ps = &projectState{}
+		c.projects[key] = ps
+	}
+	tc := t
+	*roleSlot(ps, t.Role) = &tc
+}
+
+// Signal looks up the transition for a stage, resolves the counterpart
+// target + renders the prompt UNDER the lock, then releases the lock
+// before calling the Waker (Wake may exec and block — holding the mutex
+// across it would stall all other Register/Touch/Signal calls).
+func (c *Coordinator) Signal(ctx context.Context, stage, fromRole, cwd, summary string) (SignalResult, error) {
+	res := SignalResult{Stage: stage}
+	tr, ok := Lookup(stage)
+	if !ok {
+		res.Note = "unknown stage"
+		return res, nil
+	}
+	res.WokeRole = tr.WakeRole
+	if tr.WakeRole == fromRole {
+		res.Note = "transition would wake the sender — misconfigured stage/role"
+		return res, nil
+	}
+
+	key := c.key(cwd)
+	c.mu.Lock()
+	var target *Target
+	if ps := c.projects[key]; ps != nil {
+		if slot := roleSlot(ps, tr.WakeRole); slot != nil && *slot != nil {
+			tc := **slot
+			target = &tc
+		}
+	}
+	c.mu.Unlock()
+
+	if target == nil {
+		res.Note = "no " + tr.WakeRole + " registered for this project"
+		return res, nil
+	}
+	res.TargetFound = true
+
+	if summary == "" {
+		summary = "(no summary provided — call get_peer_sessions to read the peer's full output)"
+	}
+	prompt, err := renderPrompt(tr, promptData{Project: key, FromRole: fromRole, Summary: summary})
+	if err != nil {
+		res.Note = "render prompt: " + err.Error()
+		return res, err
+	}
+
+	name, err := c.waker.WakeWith(ctx, *target, prompt)
+	if err != nil {
+		res.Note = "wake failed: " + err.Error()
+		return res, nil
+	}
+	res.WakerName = name
+	res.Dispatched = true
+	if name == "worker" {
+		// The worker fallback spawns a fresh non-interactive agent; whether
+		// its hooks/MCP fire to continue the relay chain is not yet
+		// spike-verified, so flag the handoff as best-effort rather than
+		// letting dispatched=true imply a guaranteed round-trip.
+		res.Note = "worker fallback started; hook/MCP continuation is best-effort (not yet spike-verified)"
+	}
+	return res, nil
+}
+
+// gcLocked reaps abandoned targets. Caller must hold c.mu.
+func (c *Coordinator) gcLocked(now time.Time) {
+	if now.Before(c.nextGC) {
+		return
+	}
+	cutoff := now.Add(-staleAfter)
+	for k, ps := range c.projects {
+		if ps.driver != nil && ps.driver.LastSeen.Before(cutoff) {
+			ps.driver = nil
+		}
+		if ps.reviewer != nil && ps.reviewer.LastSeen.Before(cutoff) {
+			ps.reviewer = nil
+		}
+		if ps.driver == nil && ps.reviewer == nil {
+			delete(c.projects, k)
+		}
+	}
+	c.nextGC = now.Add(gcInterval)
+}

--- a/server/internal/relay/coordinator_test.go
+++ b/server/internal/relay/coordinator_test.go
@@ -2,6 +2,7 @@ package relay
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 )
@@ -88,6 +89,158 @@ func TestSignalSenderMisconfig(t *testing.T) {
 	res, _ := c.Signal(context.Background(), StagePlanReady, RoleReviewer, "/repo", "")
 	if res.Dispatched {
 		t.Fatalf("sender==wake role should not dispatch: %+v", res)
+	}
+}
+
+func TestBusyDebounce(t *testing.T) {
+	fw := &fakeWaker{name: "fake", can: true}
+	c := newTestCoord(NewRegistry(fw))
+	c.Register(Target{Role: RoleReviewer, SessionID: "r1", CWD: "/repo"})
+	c.Register(Target{Role: RoleDriver, SessionID: "d1", CWD: "/repo"})
+
+	// First plan_ready wakes the reviewer and marks it pending.
+	if res, _ := c.Signal(context.Background(), StagePlanReady, RoleDriver, "/repo", "s"); !res.Dispatched {
+		t.Fatal("first signal should dispatch")
+	}
+	// Re-sending while the reviewer hasn't handed back must drop, not re-wake.
+	res, _ := c.Signal(context.Background(), StagePlanReady, RoleDriver, "/repo", "s")
+	if res.Dispatched {
+		t.Fatalf("duplicate signal should be dropped: %+v", res)
+	}
+	if fw.called != 1 {
+		t.Fatalf("waker called %d times, want 1 (no re-wake)", fw.called)
+	}
+	// Reviewer hands back → clears its pending and wakes the driver.
+	if res, _ := c.Signal(context.Background(), StagePlanReviewed, RoleReviewer, "/repo", "done"); !res.Dispatched {
+		t.Fatal("hand-back should dispatch to driver")
+	}
+	if fw.called != 2 {
+		t.Fatalf("waker called %d times, want 2", fw.called)
+	}
+}
+
+// TestConcurrentSignalSingleFlight asserts two concurrent identical
+// signals wake the target only once — the pending reservation is taken
+// under the lock, so the second signal sees "busy" and drops instead of
+// double-waking (or spawning two workers).
+func TestConcurrentSignalSingleFlight(t *testing.T) {
+	block := make(chan struct{})
+	fw := &fakeWaker{name: "fake", can: true, block: block}
+	c := newTestCoord(NewRegistry(fw))
+	c.Register(Target{Role: RoleReviewer, SessionID: "r1", CWD: "/repo"})
+
+	results := make(chan SignalResult, 2)
+	for i := 0; i < 2; i++ {
+		go func() {
+			res, _ := c.Signal(context.Background(), StagePlanReady, RoleDriver, "/repo", "s")
+			results <- res
+		}()
+	}
+	// One goroutine reserves + blocks in Wake; the other must drop. Wait
+	// for the dropped one to come back, then release the blocked Wake.
+	first := <-results
+	close(block)
+	second := <-results
+
+	dispatched := 0
+	for _, r := range []SignalResult{first, second} {
+		if r.Dispatched {
+			dispatched++
+		}
+	}
+	if dispatched != 1 {
+		t.Fatalf("want exactly 1 dispatch, got %d (%+v / %+v)", dispatched, first, second)
+	}
+	fw.mu.Lock()
+	defer fw.mu.Unlock()
+	if fw.called != 1 {
+		t.Fatalf("waker called %d times, want 1", fw.called)
+	}
+}
+
+// TestTargetBusyClearsReservation asserts an errTargetBusy outcome drops
+// the signal AND clears the reservation, so a later retry isn't permanently
+// blocked as "busy".
+func TestTargetBusyClearsReservation(t *testing.T) {
+	fw := &fakeWaker{name: "iterm", can: true, err: errTargetBusy}
+	c := newTestCoord(NewRegistry(fw))
+	c.Register(Target{Role: RoleReviewer, SessionID: "r1", CWD: "/repo"})
+
+	res, _ := c.Signal(context.Background(), StagePlanReady, RoleDriver, "/repo", "s")
+	if res.Dispatched || !strings.Contains(res.Note, "busy") {
+		t.Fatalf("busy wake should drop with a busy note: %+v", res)
+	}
+	// Reservation must be cleared → a second attempt actually re-tries Wake
+	// (called twice) rather than being short-circuited as still-pending.
+	c.Signal(context.Background(), StagePlanReady, RoleDriver, "/repo", "s")
+	if fw.called != 2 {
+		t.Fatalf("waker called %d times, want 2 (reservation not cleared on busy)", fw.called)
+	}
+}
+
+// TestRegisterClearsStalePending guards the crash-without-SessionEnd case:
+// a new session for a woken role must clear the stale pending so handoffs
+// aren't blocked forever (relevant when the wake-timeout is disabled).
+func TestRegisterClearsStalePending(t *testing.T) {
+	fw := &fakeWaker{name: "fake", can: true}
+	c := newTestCoord(NewRegistry(fw))
+	c.Register(Target{Role: RoleReviewer, SessionID: "r1", CWD: "/repo"})
+	c.Register(Target{Role: RoleDriver, SessionID: "d1", CWD: "/repo"})
+	c.Signal(context.Background(), StagePlanReady, RoleDriver, "/repo", "s") // pending[reviewer] set
+
+	// Reviewer crashed and restarted as a new session.
+	c.Register(Target{Role: RoleReviewer, SessionID: "r2", CWD: "/repo"})
+
+	res, _ := c.Signal(context.Background(), StagePlanReady, RoleDriver, "/repo", "s")
+	if !res.Dispatched {
+		t.Fatalf("new reviewer session should clear stale pending and allow dispatch: %+v", res)
+	}
+}
+
+func TestWakeTimeoutNudgesOriginator(t *testing.T) {
+	fw := &fakeWaker{name: "fake", can: true}
+	c := newTestCoord(NewRegistry(fw))
+	c.SetWakeTimeout(30 * time.Millisecond)
+	c.Register(Target{Role: RoleReviewer, SessionID: "r1", CWD: "/repo"})
+	c.Register(Target{Role: RoleDriver, SessionID: "d1", CWD: "/repo"})
+
+	if res, _ := c.Signal(context.Background(), StagePlanReady, RoleDriver, "/repo", "s"); !res.Dispatched {
+		t.Fatal("should dispatch to reviewer")
+	}
+	// Reviewer never hands back → after the timeout the driver is nudged.
+	deadline := time.After(2 * time.Second)
+	for {
+		fw.mu.Lock()
+		n, last := fw.called, fw.gotTarget.SessionID
+		fw.mu.Unlock()
+		if n >= 2 {
+			if last != "d1" {
+				t.Fatalf("timeout nudge woke %q, want driver d1", last)
+			}
+			return
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("timeout nudge never fired (called=%d)", n)
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+}
+
+func TestStopCancelsTimeout(t *testing.T) {
+	fw := &fakeWaker{name: "fake", can: true}
+	c := newTestCoord(NewRegistry(fw))
+	c.SetWakeTimeout(30 * time.Millisecond)
+	c.Register(Target{Role: RoleReviewer, SessionID: "r1", CWD: "/repo"})
+	c.Register(Target{Role: RoleDriver, SessionID: "d1", CWD: "/repo"})
+
+	c.Signal(context.Background(), StagePlanReady, RoleDriver, "/repo", "s")
+	c.Stop()
+	time.Sleep(80 * time.Millisecond)
+	fw.mu.Lock()
+	defer fw.mu.Unlock()
+	if fw.called != 1 {
+		t.Fatalf("Stop should cancel the timer; waker called %d times, want 1", fw.called)
 	}
 }
 

--- a/server/internal/relay/coordinator_test.go
+++ b/server/internal/relay/coordinator_test.go
@@ -172,7 +172,7 @@ func TestTargetBusyClearsReservation(t *testing.T) {
 	}
 	// Reservation must be cleared → a second attempt actually re-tries Wake
 	// (called twice) rather than being short-circuited as still-pending.
-	c.Signal(context.Background(), StagePlanReady, RoleDriver, "/repo", "s")
+	_, _ = c.Signal(context.Background(), StagePlanReady, RoleDriver, "/repo", "s")
 	if fw.called != 2 {
 		t.Fatalf("waker called %d times, want 2 (reservation not cleared on busy)", fw.called)
 	}
@@ -186,7 +186,7 @@ func TestRegisterClearsStalePending(t *testing.T) {
 	c := newTestCoord(NewRegistry(fw))
 	c.Register(Target{Role: RoleReviewer, SessionID: "r1", CWD: "/repo"})
 	c.Register(Target{Role: RoleDriver, SessionID: "d1", CWD: "/repo"})
-	c.Signal(context.Background(), StagePlanReady, RoleDriver, "/repo", "s") // pending[reviewer] set
+	_, _ = c.Signal(context.Background(), StagePlanReady, RoleDriver, "/repo", "s") // pending[reviewer] set
 
 	// Reviewer crashed and restarted as a new session.
 	c.Register(Target{Role: RoleReviewer, SessionID: "r2", CWD: "/repo"})
@@ -234,7 +234,7 @@ func TestStopCancelsTimeout(t *testing.T) {
 	c.Register(Target{Role: RoleReviewer, SessionID: "r1", CWD: "/repo"})
 	c.Register(Target{Role: RoleDriver, SessionID: "d1", CWD: "/repo"})
 
-	c.Signal(context.Background(), StagePlanReady, RoleDriver, "/repo", "s")
+	_, _ = c.Signal(context.Background(), StagePlanReady, RoleDriver, "/repo", "s")
 	c.Stop()
 	time.Sleep(80 * time.Millisecond)
 	fw.mu.Lock()

--- a/server/internal/relay/coordinator_test.go
+++ b/server/internal/relay/coordinator_test.go
@@ -1,0 +1,122 @@
+package relay
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// newTestCoord builds a Coordinator with an identity projectKey (cwd is
+// the key) so tests control isolation directly.
+func newTestCoord(w *Registry) *Coordinator {
+	return NewCoordinator(nil, w, func(cwd string) string { return cwd })
+}
+
+func TestSignalWakesCounterpart(t *testing.T) {
+	fw := &fakeWaker{name: "fake", can: true}
+	c := newTestCoord(NewRegistry(fw))
+	c.Register(Target{Role: RoleReviewer, SessionID: "r1", Agent: "codex", CWD: "/repo", Terminals: map[string]string{"tmux": "%2"}})
+
+	res, err := c.Signal(context.Background(), StagePlanReady, RoleDriver, "/repo", "the plan summary")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.Dispatched || res.WokeRole != RoleReviewer || res.WakerName != "fake" {
+		t.Fatalf("unexpected result: %+v", res)
+	}
+	if fw.gotTarget.SessionID != "r1" {
+		t.Fatalf("woke wrong target: %+v", fw.gotTarget)
+	}
+}
+
+func TestSignalNoCounterpart(t *testing.T) {
+	fw := &fakeWaker{name: "fake", can: true}
+	c := newTestCoord(NewRegistry(fw))
+
+	res, _ := c.Signal(context.Background(), StagePlanReady, RoleDriver, "/repo", "")
+	if res.Dispatched || res.TargetFound {
+		t.Fatalf("should not dispatch without a reviewer: %+v", res)
+	}
+	if fw.called != 0 {
+		t.Fatal("waker must not be called")
+	}
+}
+
+func TestProjectIsolation(t *testing.T) {
+	fw := &fakeWaker{name: "fake", can: true}
+	c := newTestCoord(NewRegistry(fw))
+	c.Register(Target{Role: RoleReviewer, SessionID: "rA", Agent: "codex", CWD: "/projA"})
+
+	res, _ := c.Signal(context.Background(), StagePlanReady, RoleDriver, "/projB", "")
+	if res.TargetFound {
+		t.Fatal("projB must not see projA's reviewer")
+	}
+}
+
+func TestUnregisterBySession(t *testing.T) {
+	fw := &fakeWaker{name: "fake", can: true}
+	c := newTestCoord(NewRegistry(fw))
+	c.Register(Target{Role: RoleReviewer, SessionID: "r1", CWD: "/repo"})
+
+	c.Unregister("/repo", RoleReviewer, "other") // mismatched session → no-op
+	if res, _ := c.Signal(context.Background(), StagePlanReady, RoleDriver, "/repo", ""); !res.TargetFound {
+		t.Fatal("mismatched-session unregister must not remove")
+	}
+
+	c.Unregister("/repo", RoleReviewer, "r1")
+	if res, _ := c.Signal(context.Background(), StagePlanReady, RoleDriver, "/repo", ""); res.TargetFound {
+		t.Fatal("matched-session unregister must remove")
+	}
+}
+
+func TestTouchRegistersWhenMissing(t *testing.T) {
+	fw := &fakeWaker{name: "fake", can: true}
+	c := newTestCoord(NewRegistry(fw))
+	c.Touch(Target{Role: RoleReviewer, SessionID: "r1", Agent: "codex", CWD: "/repo"})
+
+	if res, _ := c.Signal(context.Background(), StagePlanReady, RoleDriver, "/repo", ""); !res.TargetFound {
+		t.Fatal("Touch should register a missing target")
+	}
+}
+
+func TestSignalSenderMisconfig(t *testing.T) {
+	fw := &fakeWaker{name: "fake", can: true}
+	c := newTestCoord(NewRegistry(fw))
+	c.Register(Target{Role: RoleReviewer, SessionID: "r1", CWD: "/repo"})
+	// plan_ready wakes reviewer; if the *reviewer* sends it, that would
+	// wake itself — guard against it.
+	res, _ := c.Signal(context.Background(), StagePlanReady, RoleReviewer, "/repo", "")
+	if res.Dispatched {
+		t.Fatalf("sender==wake role should not dispatch: %+v", res)
+	}
+}
+
+// TestLockNotHeldDuringWake asserts Signal releases the mutex before
+// calling the (possibly blocking) Waker — otherwise a slow Wake would
+// stall every other Register/Touch/Signal.
+func TestLockNotHeldDuringWake(t *testing.T) {
+	block := make(chan struct{})
+	fw := &fakeWaker{name: "fake", can: true, block: block}
+	c := newTestCoord(NewRegistry(fw))
+	c.Register(Target{Role: RoleReviewer, SessionID: "r1", CWD: "/repo"})
+
+	done := make(chan struct{})
+	go func() {
+		_, _ = c.Signal(context.Background(), StagePlanReady, RoleDriver, "/repo", "s")
+		close(done)
+	}()
+
+	reg := make(chan struct{})
+	go func() {
+		c.Register(Target{Role: RoleDriver, SessionID: "d1", CWD: "/repo"})
+		close(reg)
+	}()
+
+	select {
+	case <-reg:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Register blocked — mutex held across Waker.Wake")
+	}
+	close(block)
+	<-done
+}

--- a/server/internal/relay/detach_unix.go
+++ b/server/internal/relay/detach_unix.go
@@ -1,0 +1,14 @@
+//go:build !windows
+
+package relay
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// setDetach puts the worker in its own process group so it survives the
+// tma1-server request that spawned it.
+func setDetach(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+}

--- a/server/internal/relay/detach_windows.go
+++ b/server/internal/relay/detach_windows.go
@@ -1,0 +1,11 @@
+//go:build windows
+
+package relay
+
+import "os/exec"
+
+// setDetach is a no-op on Windows (Phase 1 targets mac/linux for the
+// interactive wakers; the worker fallback still starts, just without an
+// explicit process-group detach). CREATE_NEW_PROCESS_GROUP can be added
+// here if Windows worker support is pursued.
+func setDetach(cmd *exec.Cmd) {}

--- a/server/internal/relay/paste.go
+++ b/server/internal/relay/paste.go
@@ -1,0 +1,32 @@
+package relay
+
+import "strings"
+
+// Bracketed-paste control sequences. Wrapping injected text in these makes
+// a REPL treat embedded newlines as pasted content (a single multi-line
+// block) instead of submitting line-by-line; a separate Enter then submits
+// the whole block.
+const (
+	bracketStart = "\x1b[200~"
+	bracketEnd   = "\x1b[201~"
+)
+
+// sanitizeForPaste strips any literal bracketed-paste END marker from the
+// text so a crafted prompt/summary can't close the paste early and have
+// the trailing bytes interpreted as keystrokes.
+func sanitizeForPaste(s string) string {
+	return strings.ReplaceAll(s, bracketEnd, "")
+}
+
+// wrapBracketed sanitizes then wraps text in bracketed-paste markers.
+func wrapBracketed(s string) string {
+	return bracketStart + sanitizeForPaste(s) + bracketEnd
+}
+
+// collapseLines folds a multi-line prompt onto one line for the
+// single-line fallback (terminals that don't honour bracketed paste).
+// Runs of whitespace become a single space so the prompt submits as one
+// REPL line on a single Enter.
+func collapseLines(s string) string {
+	return strings.Join(strings.Fields(s), " ")
+}

--- a/server/internal/relay/target.go
+++ b/server/internal/relay/target.go
@@ -1,0 +1,72 @@
+package relay
+
+import (
+	"strings"
+	"time"
+)
+
+// Roles. A project has at most one driver and one reviewer registered
+// at a time (Phase 1 assumption).
+const (
+	RoleDriver   = "driver"
+	RoleReviewer = "reviewer"
+)
+
+const (
+	maxTerminalHeader = 1024
+	maxTerminalValue  = 256
+)
+
+// Target identifies where a role's terminal lives. It is populated from
+// identifiers the hook script collects — the script runs inside the
+// agent's terminal and can read $TMUX_PANE / $ITERM_SESSION_ID / etc.,
+// whereas tma1-server is a separate long-lived process whose own env is
+// unrelated to any agent terminal.
+type Target struct {
+	Role      string            // RoleDriver | RoleReviewer
+	SessionID string            // agent session id (best-effort; may be empty)
+	Agent     string            // "claude_code" | "codex" — selects the worker fallback command
+	CWD       string            // working dir, resolved to a project key by the Coordinator
+	Terminals map[string]string // "tmux"->$TMUX_PANE, "iterm"->$ITERM_SESSION_ID, ...
+	LastSeen  time.Time
+}
+
+// ValidRole reports whether r is a recognised relay role.
+func ValidRole(r string) bool {
+	return r == RoleDriver || r == RoleReviewer
+}
+
+// ParseTerminals decodes the X-Tma1-Terminal header value
+// ("tmux=%5;iterm=w0t0p0:UUID;wezterm=;kitty=") into a map, dropping
+// empty values. It defends against CR/LF injection and oversized input
+// since the value originates from a client-controlled header.
+func ParseTerminals(header string) map[string]string {
+	if header == "" {
+		return nil
+	}
+	if len(header) > maxTerminalHeader {
+		header = header[:maxTerminalHeader]
+	}
+	header = strings.NewReplacer("\r", "", "\n", "").Replace(header)
+
+	out := map[string]string{}
+	for _, pair := range strings.Split(header, ";") {
+		kv := strings.SplitN(pair, "=", 2)
+		if len(kv) != 2 {
+			continue
+		}
+		k := strings.TrimSpace(kv[0])
+		v := strings.TrimSpace(kv[1])
+		if k == "" || v == "" {
+			continue
+		}
+		if len(v) > maxTerminalValue {
+			v = v[:maxTerminalValue]
+		}
+		out[k] = v
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}

--- a/server/internal/relay/target_test.go
+++ b/server/internal/relay/target_test.go
@@ -1,0 +1,45 @@
+package relay
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestParseTerminals(t *testing.T) {
+	got := ParseTerminals("tmux=%5;iterm=w0t0p0:UUID;wezterm=;kitty=")
+	want := map[string]string{"tmux": "%5", "iterm": "w0t0p0:UUID"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+
+	if ParseTerminals("") != nil {
+		t.Fatal("empty header should yield nil")
+	}
+	if ParseTerminals("tmux=;iterm=") != nil {
+		t.Fatal("all-empty values should yield nil")
+	}
+
+	// CR/LF must be stripped so a crafted value can't inject a header line.
+	got2 := ParseTerminals("tmux=%5\r\nX-Evil: 1")
+	for k, v := range got2 {
+		if strings.ContainsAny(v, "\r\n") {
+			t.Fatalf("CR/LF leaked into %s=%q", k, v)
+		}
+	}
+
+	// Oversized value is capped.
+	long := ParseTerminals("tmux=" + strings.Repeat("a", maxTerminalValue+50))
+	if len(long["tmux"]) != maxTerminalValue {
+		t.Fatalf("value not capped: len=%d", len(long["tmux"]))
+	}
+}
+
+func TestValidRole(t *testing.T) {
+	if !ValidRole(RoleDriver) || !ValidRole(RoleReviewer) {
+		t.Fatal("driver/reviewer should be valid")
+	}
+	if ValidRole("") || ValidRole("bogus") {
+		t.Fatal("empty/bogus should be invalid")
+	}
+}

--- a/server/internal/relay/token.go
+++ b/server/internal/relay/token.go
@@ -1,0 +1,70 @@
+// Package relay implements the TMA1 driver↔reviewer handoff coordinator.
+//
+// It maintains per-project in-memory state mapping the two roles
+// (driver / reviewer) to the terminal each runs in, and on a milestone
+// signal wakes the counterpart terminal via a pluggable Waker (tmux /
+// worker). The package is platform-independent: terminal-specific
+// delivery lives behind the Waker interface.
+package relay
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const tokenFileName = "relay_token"
+
+// LoadOrCreateToken reads <dataDir>/relay_token, generating a random
+// 256-bit secret (hex) on first use and persisting it 0600. Both the
+// server (which validates the token on /api/relay/signal) and the
+// install subcommand (which injects it into the MCP child's env) call
+// this against the same dataDir, so the two always agree.
+//
+// The /api/relay/signal endpoint injects terminal text and spawns
+// worker processes; an Origin check can't gate it (non-browser callers
+// send no Origin), so a shared local secret is the Phase 1 guard.
+func LoadOrCreateToken(dataDir string) (string, error) {
+	path := filepath.Join(dataDir, tokenFileName)
+	if b, err := os.ReadFile(path); err == nil {
+		if tok := strings.TrimSpace(string(b)); tok != "" {
+			// Repair permission drift — the token guards an endpoint that
+			// injects terminal text / spawns workers, so it must stay 0600
+			// even if a previous run (or the user) left it more permissive.
+			if info, statErr := os.Stat(path); statErr == nil && info.Mode().Perm() != 0o600 {
+				_ = os.Chmod(path, 0o600) // best-effort: the token is still usable if this fails
+			}
+			return tok, nil
+		}
+	}
+
+	buf := make([]byte, 32)
+	if _, err := rand.Read(buf); err != nil {
+		return "", fmt.Errorf("generate relay token: %w", err)
+	}
+	tok := hex.EncodeToString(buf)
+
+	if err := os.MkdirAll(dataDir, 0o755); err != nil {
+		return "", fmt.Errorf("create data dir: %w", err)
+	}
+	if err := os.WriteFile(path, []byte(tok), 0o600); err != nil {
+		return "", fmt.Errorf("write relay token: %w", err)
+	}
+	return tok, nil
+}
+
+// LoadToken reads an existing relay token WITHOUT creating one, returning
+// ("", false) when no token file exists yet. Used by dry-run install so
+// it can surface an already-provisioned token without the file-write side
+// effect of LoadOrCreateToken.
+func LoadToken(dataDir string) (string, bool) {
+	b, err := os.ReadFile(filepath.Join(dataDir, tokenFileName))
+	if err != nil {
+		return "", false
+	}
+	tok := strings.TrimSpace(string(b))
+	return tok, tok != ""
+}

--- a/server/internal/relay/token_test.go
+++ b/server/internal/relay/token_test.go
@@ -1,0 +1,35 @@
+package relay
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadOrCreateToken(t *testing.T) {
+	dir := t.TempDir()
+
+	tok1, err := LoadOrCreateToken(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tok1) != 64 { // 32 bytes hex-encoded
+		t.Fatalf("want 64 hex chars, got %d (%q)", len(tok1), tok1)
+	}
+
+	info, err := os.Stat(filepath.Join(dir, tokenFileName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Fatalf("token file perm = %v, want 0600", perm)
+	}
+
+	tok2, err := LoadOrCreateToken(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tok2 != tok1 {
+		t.Fatalf("token changed across calls: %q != %q", tok1, tok2)
+	}
+}

--- a/server/internal/relay/transition.go
+++ b/server/internal/relay/transition.go
@@ -1,0 +1,94 @@
+package relay
+
+import (
+	"sort"
+	"strings"
+	"text/template"
+)
+
+// Milestone stages that drive the handoff state machine.
+const (
+	StagePlanReady    = "plan_ready"
+	StagePlanReviewed = "plan_reviewed"
+	StageImplDone     = "impl_done"
+	StageCodeReviewed = "code_reviewed"
+)
+
+// Transition encodes, for a milestone stage, which role to wake and the
+// instruction prompt to deliver to that role's terminal.
+type Transition struct {
+	WakeRole   string
+	promptTmpl *template.Template
+}
+
+// promptData is the template context for a wake prompt.
+type promptData struct {
+	Project  string
+	FromRole string
+	Summary  string
+}
+
+// Prompt text. The reviewer-side prompts deliberately script the
+// high-signal review motion (pull → read real code → graded findings →
+// revision order → hand back) so an auto-triggered review matches the
+// quality of a hand-driven one. The driver-side prompts inline the
+// peer's summary so the driver needn't re-pull the full session.
+const (
+	planReadyPrompt = "A peer agent (the driver) just finished a PLAN for project {{.Project}} and handed it off for review.\n\n" +
+		"Do a real review, not a skim:\n" +
+		"1. Pull the full plan — call get_peer_sessions (agent_source=claude_code) or read the plan file directly.\n" +
+		"2. READ the actual code the plan touches before judging — do not review from the plan text alone.\n" +
+		"3. Report findings graded P1 (blocking) / P2 (should-fix), each with file:line references.\n" +
+		"4. End with a minimal revision order.\n" +
+		"5. When done, call tma1_handoff with stage=\"plan_reviewed\" and summary set to your graded findings."
+
+	planReviewedPrompt = "The reviewer finished reviewing your plan. Their findings:\n\n{{.Summary}}\n\n" +
+		"Apply the P1 items, decide on each P2, update the plan, then continue."
+
+	implDonePrompt = "A peer agent (the driver) finished an IMPLEMENTATION for project {{.Project}}.\n\n" +
+		"1. Pull the latest work — get_peer_sessions (agent_source=claude_code) or inspect the diff (git diff).\n" +
+		"2. Run your code-review skill against the REAL changes, not the description.\n" +
+		"3. Report findings graded P1/P2 with file:line references, then a minimal fix order.\n" +
+		"4. When done, call tma1_handoff with stage=\"code_reviewed\" and summary set to your review report."
+
+	codeReviewedPrompt = "The reviewer finished reviewing your implementation. Their report:\n\n{{.Summary}}\n\n" +
+		"Apply the P1 fixes, decide on each P2, then run your own review pass before finishing."
+)
+
+// transitions is the built-in, hardcoded state machine for Phase 1.
+// Made configurable in a later phase.
+var transitions = map[string]Transition{
+	StagePlanReady:    {WakeRole: RoleReviewer, promptTmpl: mustTmpl(planReadyPrompt)},
+	StagePlanReviewed: {WakeRole: RoleDriver, promptTmpl: mustTmpl(planReviewedPrompt)},
+	StageImplDone:     {WakeRole: RoleReviewer, promptTmpl: mustTmpl(implDonePrompt)},
+	StageCodeReviewed: {WakeRole: RoleDriver, promptTmpl: mustTmpl(codeReviewedPrompt)},
+}
+
+func mustTmpl(s string) *template.Template {
+	return template.Must(template.New("relay_prompt").Parse(s))
+}
+
+// Lookup returns the transition for a stage, false if the stage is unknown.
+func Lookup(stage string) (Transition, bool) {
+	t, ok := transitions[stage]
+	return t, ok
+}
+
+// ValidStages returns all known stage names, sorted, for validation
+// errors and the MCP tool description.
+func ValidStages() []string {
+	out := make([]string, 0, len(transitions))
+	for k := range transitions {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func renderPrompt(t Transition, d promptData) (string, error) {
+	var b strings.Builder
+	if err := t.promptTmpl.Execute(&b, d); err != nil {
+		return "", err
+	}
+	return b.String(), nil
+}

--- a/server/internal/relay/transition_test.go
+++ b/server/internal/relay/transition_test.go
@@ -1,0 +1,55 @@
+package relay
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestLookupAndStages(t *testing.T) {
+	for _, s := range []string{StagePlanReady, StagePlanReviewed, StageImplDone, StageCodeReviewed} {
+		if _, ok := Lookup(s); !ok {
+			t.Fatalf("stage %q should resolve", s)
+		}
+	}
+	if _, ok := Lookup("nope"); ok {
+		t.Fatal("unknown stage should miss")
+	}
+	if got := ValidStages(); len(got) != 4 {
+		t.Fatalf("want 4 stages, got %d (%v)", len(got), got)
+	}
+}
+
+func TestWakeRoles(t *testing.T) {
+	cases := map[string]string{
+		StagePlanReady:    RoleReviewer,
+		StageImplDone:     RoleReviewer,
+		StagePlanReviewed: RoleDriver,
+		StageCodeReviewed: RoleDriver,
+	}
+	for stage, want := range cases {
+		tr, _ := Lookup(stage)
+		if tr.WakeRole != want {
+			t.Fatalf("%s wake=%s, want %s", stage, tr.WakeRole, want)
+		}
+	}
+}
+
+func TestRenderPrompt(t *testing.T) {
+	tr, _ := Lookup(StagePlanReady)
+	out, err := renderPrompt(tr, promptData{Project: "myproj"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "myproj") {
+		t.Fatalf("project not substituted: %s", out)
+	}
+
+	tr2, _ := Lookup(StagePlanReviewed)
+	out2, err := renderPrompt(tr2, promptData{Summary: "FINDINGS-XYZ"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out2, "FINDINGS-XYZ") {
+		t.Fatalf("summary not substituted: %s", out2)
+	}
+}

--- a/server/internal/relay/waker.go
+++ b/server/internal/relay/waker.go
@@ -1,0 +1,68 @@
+package relay
+
+import (
+	"context"
+	"errors"
+)
+
+// Waker delivers a wake prompt to a target's terminal. Implementations
+// declare via CanWake whether they can reach a given target; the
+// Registry tries them in reliability order.
+type Waker interface {
+	Name() string
+	CanWake(t Target) bool
+	Wake(ctx context.Context, t Target, prompt string) error
+}
+
+var (
+	errNoWaker     = errors.New("no waker can reach the target")
+	errNoWorkerBin = errors.New("no agent binary resolved for worker fallback")
+)
+
+// Registry holds wakers in reliability order (most reliable first, the
+// universal worker fallback last) and dispatches to the first one that
+// can reach the target.
+type Registry struct {
+	wakers []Waker
+}
+
+func NewRegistry(wakers ...Waker) *Registry {
+	return &Registry{wakers: wakers}
+}
+
+// CanWake reports whether any registered waker can reach the target.
+func (r *Registry) CanWake(t Target) bool {
+	for _, w := range r.wakers {
+		if w.CanWake(t) {
+			return true
+		}
+	}
+	return false
+}
+
+// WakeWith tries each applicable waker in order; the first whose Wake
+// succeeds wins and its Name is returned. A waker that errors falls
+// through to the next. Returns an error only when no waker applied or
+// every applicable one failed.
+func (r *Registry) WakeWith(ctx context.Context, t Target, prompt string) (string, error) {
+	var lastErr error
+	applied := false
+	for _, w := range r.wakers {
+		if !w.CanWake(t) {
+			continue
+		}
+		applied = true
+		if err := w.Wake(ctx, t, prompt); err != nil {
+			lastErr = err
+			continue
+		}
+		return w.Name(), nil
+	}
+	if lastErr != nil {
+		return "", lastErr
+	}
+	if !applied {
+		return "", errNoWaker
+	}
+	return "", errNoWaker
+}

--- a/server/internal/relay/waker.go
+++ b/server/internal/relay/waker.go
@@ -17,6 +17,14 @@ type Waker interface {
 var (
 	errNoWaker     = errors.New("no waker can reach the target")
 	errNoWorkerBin = errors.New("no agent binary resolved for worker fallback")
+	// errTargetBusy means the target terminal is reachable but actively
+	// processing. WakeWith stops on it (does NOT fall through to a less
+	// precise waker) so we never spawn a duplicate worker for a terminal
+	// that's simply busy.
+	errTargetBusy = errors.New("target terminal is busy")
+	// errSessionNotFound means the recorded terminal id no longer maps to
+	// a live session (closed / reused / forged). WakeWith falls through.
+	errSessionNotFound = errors.New("terminal session not found")
 )
 
 // Registry holds wakers in reliability order (most reliable first, the
@@ -53,6 +61,11 @@ func (r *Registry) WakeWith(ctx context.Context, t Target, prompt string) (strin
 		}
 		applied = true
 		if err := w.Wake(ctx, t, prompt); err != nil {
+			// A busy terminal is reachable — don't fall through to a worker
+			// and duplicate the agent. Surface it as-is.
+			if errors.Is(err, errTargetBusy) {
+				return "", err
+			}
 			lastErr = err
 			continue
 		}

--- a/server/internal/relay/waker_iterm.go
+++ b/server/internal/relay/waker_iterm.go
@@ -1,0 +1,148 @@
+package relay
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"regexp"
+	"runtime"
+	"strings"
+)
+
+// osaRunner runs an AppleScript (read from stdin) with positional argv and
+// returns trimmed stdout. Injectable so tests assert the script + argv
+// without driving real osascript.
+type osaRunner func(ctx context.Context, script string, argv ...string) (string, error)
+
+// itermUUIDRe matches the canonical UUID that iTerm2 exposes as a
+// session's AppleScript `id`. ITERM_SESSION_ID is "w<i>t<j>p<k>:UUID";
+// only the UUID after the last colon is the AppleScript id.
+var itermUUIDRe = regexp.MustCompile(`^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$`)
+
+// itermUUID extracts and validates the AppleScript session id from an
+// ITERM_SESSION_ID value. Returns "" for anything that isn't a UUID, so a
+// malformed/forged header can never be substituted into the script argv.
+func itermUUID(v string) string {
+	if i := strings.LastIndex(v, ":"); i >= 0 {
+		v = v[i+1:]
+	}
+	if !itermUUIDRe.MatchString(v) {
+		return ""
+	}
+	return v
+}
+
+// itermInjectScript locates the session by id and injects the text. It
+// types the text without a trailing return (newline no) then sends a lone
+// return to submit, mirroring the tmux two-step. The text is passed via
+// argv (never interpolated into the source), so there's no AppleScript
+// injection surface. Return tokens distinguish the outcomes:
+//
+//	OK       — injected
+//	BUSY     — busy gate on and the session is actively processing
+//	NOTFOUND — no session with that id (stale/forged/closed)
+const itermInjectScript = `on run argv
+  set theID to item 1 of argv
+  set theText to item 2 of argv
+  set gate to item 3 of argv
+  tell application "iTerm2"
+    repeat with w in windows
+      repeat with tb in tabs of w
+        repeat with s in sessions of tb
+          if id of s is theID then
+            if gate is "1" and (is processing of s) then
+              return "BUSY"
+            end if
+            tell s
+              write text theText newline no
+              write text "" newline yes
+            end tell
+            return "OK"
+          end if
+        end repeat
+      end repeat
+    end repeat
+  end tell
+  return "NOTFOUND"
+end run`
+
+// ItermWaker injects the prompt into an iTerm2 session via osascript. This
+// is the visible-wake path for iTerm users who aren't inside tmux.
+type ItermWaker struct {
+	osascript string // resolved osascript path; "" → unavailable
+	enabled   bool   // darwin + osascript present
+	busyGate  bool   // skip injection when the session is actively processing
+	bracketed bool   // wrap multi-line prompts in bracketed paste (else collapse to one line)
+	run       osaRunner
+	logger    *slog.Logger
+}
+
+func NewItermWaker(logger *slog.Logger) *ItermWaker {
+	bin := lookCmd("TMA1_OSASCRIPT_PATH", "osascript")
+	w := &ItermWaker{
+		osascript: bin,
+		enabled:   runtime.GOOS == "darwin" && bin != "",
+		busyGate:  os.Getenv("TMA1_RELAY_ITERM_BUSY_GATE") != "0",
+		bracketed: os.Getenv("TMA1_RELAY_BRACKETED_PASTE") != "0",
+		logger:    logger,
+	}
+	w.run = func(ctx context.Context, script string, argv ...string) (string, error) {
+		args := append([]string{"-"}, argv...) // "-" → read script from stdin
+		cmd := exec.CommandContext(ctx, w.osascript, args...)
+		cmd.Stdin = strings.NewReader(script)
+		out, err := cmd.Output()
+		if err != nil {
+			// Surface osascript's stderr (e.g. TCC automation denied: -1743)
+			// so the SignalResult.Note is diagnosable instead of "exit status 1".
+			var ee *exec.ExitError
+			if errors.As(err, &ee) && len(ee.Stderr) > 0 {
+				err = fmt.Errorf("%w: %s", err, strings.TrimSpace(string(ee.Stderr)))
+			}
+		}
+		return strings.TrimSpace(string(out)), err
+	}
+	return w
+}
+
+func (w *ItermWaker) Name() string { return "iterm" }
+
+func (w *ItermWaker) CanWake(t Target) bool {
+	return w.enabled && itermUUID(t.Terminals["iterm"]) != ""
+}
+
+// Wake injects prompt into the iTerm session. A BUSY result maps to
+// errTargetBusy (the Registry does NOT fall through to the worker — the
+// real terminal is reachable, just busy), NOTFOUND to errSessionNotFound
+// (the Registry falls through). Any osascript failure (e.g. TCC automation
+// not authorised → -1743) is returned so the caller can surface it.
+func (w *ItermWaker) Wake(ctx context.Context, t Target, prompt string) error {
+	uuid := itermUUID(t.Terminals["iterm"])
+	if uuid == "" {
+		return errSessionNotFound
+	}
+
+	text := collapseLines(prompt)
+	if w.bracketed {
+		text = wrapBracketed(prompt)
+	}
+	gate := "0"
+	if w.busyGate {
+		gate = "1"
+	}
+
+	out, err := w.run(ctx, itermInjectScript, uuid, text, gate)
+	if err != nil {
+		return err
+	}
+	switch out {
+	case "OK":
+		return nil
+	case "BUSY":
+		return errTargetBusy
+	default: // NOTFOUND or anything unexpected
+		return errSessionNotFound
+	}
+}

--- a/server/internal/relay/waker_iterm_test.go
+++ b/server/internal/relay/waker_iterm_test.go
@@ -1,0 +1,129 @@
+package relay
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestItermUUID(t *testing.T) {
+	cases := map[string]string{
+		"w1t0p0:5374D768-20C4-4E2A-B307-B5A16EE76AF2": "5374D768-20C4-4E2A-B307-B5A16EE76AF2",
+		"5374D768-20C4-4E2A-B307-B5A16EE76AF2":        "5374D768-20C4-4E2A-B307-B5A16EE76AF2",
+		"":                                            "",
+		"w1t0p0:":                                     "",
+		"w1t0p0:not-uuid":                             "",
+		"garbage":                                     "",
+	}
+	for in, want := range cases {
+		if got := itermUUID(in); got != want {
+			t.Errorf("itermUUID(%q)=%q want %q", in, got, want)
+		}
+	}
+}
+
+// newTestIterm builds an ItermWaker bypassing the darwin/osascript gate so
+// the injected runner is what executes.
+func newTestIterm(run osaRunner, bracketed, busyGate bool) *ItermWaker {
+	return &ItermWaker{enabled: true, osascript: "osascript", bracketed: bracketed, busyGate: busyGate, run: run}
+}
+
+func TestItermWakerCanWake(t *testing.T) {
+	w := newTestIterm(nil, true, true)
+	if w.CanWake(Target{}) {
+		t.Fatal("no iterm id → should not CanWake")
+	}
+	if !w.CanWake(Target{Terminals: map[string]string{"iterm": "w1t0p0:5374D768-20C4-4E2A-B307-B5A16EE76AF2"}}) {
+		t.Fatal("valid iterm id → should CanWake")
+	}
+	if w.CanWake(Target{Terminals: map[string]string{"iterm": "w1t0p0:bogus"}}) {
+		t.Fatal("invalid uuid → should not CanWake")
+	}
+}
+
+func TestItermWakerWakeBracketed(t *testing.T) {
+	var gotScript string
+	var gotArgv []string
+	run := func(_ context.Context, script string, argv ...string) (string, error) {
+		gotScript, gotArgv = script, argv
+		return "OK", nil
+	}
+	w := newTestIterm(run, true, true)
+	tgt := Target{Terminals: map[string]string{"iterm": "w1t0p0:5374D768-20C4-4E2A-B307-B5A16EE76AF2"}}
+
+	if err := w.Wake(context.Background(), tgt, "line1\nline2"); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(gotScript, "is processing") {
+		t.Fatal("script should query is processing")
+	}
+	if len(gotArgv) != 3 {
+		t.Fatalf("want 3 argv, got %v", gotArgv)
+	}
+	if gotArgv[0] != "5374D768-20C4-4E2A-B307-B5A16EE76AF2" {
+		t.Fatalf("argv[0] uuid = %q", gotArgv[0])
+	}
+	if gotArgv[1] != bracketStart+"line1\nline2"+bracketEnd {
+		t.Fatalf("argv[1] not bracketed: %q", gotArgv[1])
+	}
+	if gotArgv[2] != "1" {
+		t.Fatalf("busy gate flag = %q want 1", gotArgv[2])
+	}
+}
+
+func TestItermWakerSingleLineFallback(t *testing.T) {
+	var gotArgv []string
+	run := func(_ context.Context, _ string, argv ...string) (string, error) {
+		gotArgv = argv
+		return "OK", nil
+	}
+	w := newTestIterm(run, false, false) // bracketed off, gate off
+	tgt := Target{Terminals: map[string]string{"iterm": "5374D768-20C4-4E2A-B307-B5A16EE76AF2"}}
+
+	if err := w.Wake(context.Background(), tgt, "line1\n  line2\tline3"); err != nil {
+		t.Fatal(err)
+	}
+	if gotArgv[1] != "line1 line2 line3" {
+		t.Fatalf("collapsed text = %q", gotArgv[1])
+	}
+	if gotArgv[2] != "0" {
+		t.Fatalf("busy gate flag = %q want 0", gotArgv[2])
+	}
+}
+
+func TestItermWakerResultMapping(t *testing.T) {
+	tgt := Target{Terminals: map[string]string{"iterm": "5374D768-20C4-4E2A-B307-B5A16EE76AF2"}}
+	cases := []struct {
+		out  string
+		want error
+	}{
+		{"OK", nil},
+		{"BUSY", errTargetBusy},
+		{"NOTFOUND", errSessionNotFound},
+		{"weird", errSessionNotFound},
+	}
+	for _, tc := range cases {
+		w := newTestIterm(func(_ context.Context, _ string, _ ...string) (string, error) {
+			return tc.out, nil
+		}, true, true)
+		err := w.Wake(context.Background(), tgt, "x")
+		if !errors.Is(err, tc.want) {
+			t.Errorf("out=%q → err=%v want %v", tc.out, err, tc.want)
+		}
+	}
+}
+
+func TestRegistryBusyDoesNotFallThrough(t *testing.T) {
+	busy := &fakeWaker{name: "iterm", can: true, err: errTargetBusy}
+	worker := &fakeWaker{name: "worker", can: true}
+	r := NewRegistry(busy, worker)
+
+	_, err := r.WakeWith(context.Background(), Target{}, "p")
+	if !errors.Is(err, errTargetBusy) {
+		t.Fatalf("want errTargetBusy, got %v", err)
+	}
+	if worker.called != 0 {
+		t.Fatal("worker must not run when the real terminal is busy")
+	}
+}

--- a/server/internal/relay/waker_test.go
+++ b/server/internal/relay/waker_test.go
@@ -3,6 +3,7 @@ package relay
 import (
 	"context"
 	"reflect"
+	"strings"
 	"sync"
 	"testing"
 )
@@ -91,16 +92,61 @@ func TestTmuxWakerArgs(t *testing.T) {
 	if err := w.Wake(context.Background(), pane, "hello world"); err != nil {
 		t.Fatal(err)
 	}
-	if len(calls) != 2 {
-		t.Fatalf("want 2 send-keys calls, got %d", len(calls))
+	if len(calls) != 3 {
+		t.Fatalf("want 3 tmux calls, got %d", len(calls))
 	}
-	want0 := []string{"tmux", "send-keys", "-t", "%5", "-l", "--", "hello world"}
+	// set-buffer uses a per-call buffer name; capture it and assert the
+	// paste-buffer reuses the SAME name (else concurrent handoffs clobber).
+	if calls[0][0] != "tmux" || calls[0][1] != "set-buffer" || calls[0][2] != "-b" {
+		t.Fatalf("call[0] not set-buffer: %v", calls[0])
+	}
+	buf := calls[0][3]
+	if !strings.HasPrefix(buf, "tma1-relay-") {
+		t.Fatalf("buffer name = %q, want tma1-relay- prefix", buf)
+	}
+	want0 := []string{"tmux", "set-buffer", "-b", buf, "--", "hello world"}
 	if !reflect.DeepEqual(calls[0], want0) {
 		t.Fatalf("call[0]=%v want %v", calls[0], want0)
 	}
-	want1 := []string{"tmux", "send-keys", "-t", "%5", "Enter"}
+	want1 := []string{"tmux", "paste-buffer", "-t", "%5", "-b", buf, "-p", "-r", "-d"}
 	if !reflect.DeepEqual(calls[1], want1) {
 		t.Fatalf("call[1]=%v want %v", calls[1], want1)
+	}
+	want2 := []string{"tmux", "send-keys", "-t", "%5", "Enter"}
+	if !reflect.DeepEqual(calls[2], want2) {
+		t.Fatalf("call[2]=%v want %v", calls[2], want2)
+	}
+}
+
+func TestTmuxWakerUniqueBuffers(t *testing.T) {
+	var bufs []string
+	w := &TmuxWaker{bin: "tmux", run: func(_ context.Context, _ string, args ...string) error {
+		if len(args) >= 3 && args[0] == "set-buffer" {
+			bufs = append(bufs, args[2])
+		}
+		return nil
+	}}
+	pane := Target{Terminals: map[string]string{"tmux": "%5"}}
+	_ = w.Wake(context.Background(), pane, "a")
+	_ = w.Wake(context.Background(), pane, "b")
+	if len(bufs) != 2 || bufs[0] == bufs[1] {
+		t.Fatalf("buffers must be unique per Wake, got %v", bufs)
+	}
+}
+
+func TestTmuxWakerSanitizesPasteEnd(t *testing.T) {
+	var calls [][]string
+	w := &TmuxWaker{bin: "tmux", run: func(_ context.Context, name string, args ...string) error {
+		calls = append(calls, append([]string{name}, args...))
+		return nil
+	}}
+	pane := Target{Terminals: map[string]string{"tmux": "%5"}}
+	// An embedded paste-end marker must be stripped before set-buffer.
+	if err := w.Wake(context.Background(), pane, "a"+bracketEnd+"b"); err != nil {
+		t.Fatal(err)
+	}
+	if got := calls[0][len(calls[0])-1]; got != "ab" {
+		t.Fatalf("set-buffer payload not sanitised: %q", got)
 	}
 }
 

--- a/server/internal/relay/waker_test.go
+++ b/server/internal/relay/waker_test.go
@@ -1,0 +1,157 @@
+package relay
+
+import (
+	"context"
+	"reflect"
+	"sync"
+	"testing"
+)
+
+// fakeWaker is a test double shared across relay tests.
+type fakeWaker struct {
+	name  string
+	can   bool
+	err   error
+	block chan struct{} // when non-nil, Wake blocks until it's closed
+
+	mu        sync.Mutex
+	called    int
+	gotTarget Target
+	gotPrompt string
+}
+
+func (f *fakeWaker) Name() string          { return f.name }
+func (f *fakeWaker) CanWake(t Target) bool { return f.can }
+func (f *fakeWaker) Wake(_ context.Context, t Target, prompt string) error {
+	if f.block != nil {
+		<-f.block
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.called++
+	f.gotTarget = t
+	f.gotPrompt = prompt
+	return f.err
+}
+
+func TestRegistryPicksFirstCanWake(t *testing.T) {
+	a := &fakeWaker{name: "a", can: false}
+	b := &fakeWaker{name: "b", can: true}
+	c := &fakeWaker{name: "c", can: true}
+	r := NewRegistry(a, b, c)
+
+	name, err := r.WakeWith(context.Background(), Target{}, "p")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if name != "b" {
+		t.Fatalf("want b, got %s", name)
+	}
+	if c.called != 0 {
+		t.Fatal("c should not have been called once b succeeded")
+	}
+}
+
+func TestRegistryFallThroughOnError(t *testing.T) {
+	a := &fakeWaker{name: "a", can: true, err: errNoWorkerBin}
+	b := &fakeWaker{name: "b", can: true}
+	r := NewRegistry(a, b)
+
+	name, err := r.WakeWith(context.Background(), Target{}, "p")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if name != "b" {
+		t.Fatalf("want b after a errored, got %s", name)
+	}
+}
+
+func TestRegistryNoApplicable(t *testing.T) {
+	r := NewRegistry(&fakeWaker{name: "a", can: false})
+	if _, err := r.WakeWith(context.Background(), Target{}, "p"); err == nil {
+		t.Fatal("want error when no waker applies")
+	}
+}
+
+func TestTmuxWakerArgs(t *testing.T) {
+	var calls [][]string
+	w := &TmuxWaker{bin: "tmux", run: func(_ context.Context, name string, args ...string) error {
+		calls = append(calls, append([]string{name}, args...))
+		return nil
+	}}
+
+	if w.CanWake(Target{}) {
+		t.Fatal("no pane → should not CanWake")
+	}
+	pane := Target{Terminals: map[string]string{"tmux": "%5"}}
+	if !w.CanWake(pane) {
+		t.Fatal("pane present → should CanWake")
+	}
+
+	if err := w.Wake(context.Background(), pane, "hello world"); err != nil {
+		t.Fatal(err)
+	}
+	if len(calls) != 2 {
+		t.Fatalf("want 2 send-keys calls, got %d", len(calls))
+	}
+	want0 := []string{"tmux", "send-keys", "-t", "%5", "-l", "--", "hello world"}
+	if !reflect.DeepEqual(calls[0], want0) {
+		t.Fatalf("call[0]=%v want %v", calls[0], want0)
+	}
+	want1 := []string{"tmux", "send-keys", "-t", "%5", "Enter"}
+	if !reflect.DeepEqual(calls[1], want1) {
+		t.Fatalf("call[1]=%v want %v", calls[1], want1)
+	}
+}
+
+func TestTmuxWakerNoBin(t *testing.T) {
+	w := &TmuxWaker{bin: "", run: defaultExecRunner}
+	if w.CanWake(Target{Terminals: map[string]string{"tmux": "%5"}}) {
+		t.Fatal("no tmux binary → should not CanWake")
+	}
+}
+
+func TestWorkerWakerArgs(t *testing.T) {
+	type call struct {
+		dir, name string
+		args      []string
+	}
+	var got call
+	w := &WorkerWaker{codexBin: "/bin/codex", claudeBin: "/bin/claude", start: func(dir, name string, args ...string) error {
+		got = call{dir, name, args}
+		return nil
+	}}
+
+	if !w.CanWake(Target{Agent: "codex"}) {
+		t.Fatal("codex resolved → CanWake")
+	}
+	if err := w.Wake(context.Background(), Target{Agent: "codex", CWD: "/repo"}, "do review"); err != nil {
+		t.Fatal(err)
+	}
+	if got.name != "/bin/codex" || got.dir != "/repo" {
+		t.Fatalf("codex spawn = %+v", got)
+	}
+	if !reflect.DeepEqual(got.args, []string{"exec", "do review"}) {
+		t.Fatalf("codex args = %v", got.args)
+	}
+
+	if err := w.Wake(context.Background(), Target{Agent: "claude_code", CWD: "/repo"}, "fix"); err != nil {
+		t.Fatal(err)
+	}
+	if got.name != "/bin/claude" {
+		t.Fatalf("claude spawn = %+v", got)
+	}
+	if !reflect.DeepEqual(got.args, []string{"-p", "fix"}) {
+		t.Fatalf("claude args = %v", got.args)
+	}
+}
+
+func TestWorkerWakerNoBin(t *testing.T) {
+	w := &WorkerWaker{}
+	if w.CanWake(Target{Agent: "codex"}) {
+		t.Fatal("no binary → should not CanWake")
+	}
+	if err := w.Wake(context.Background(), Target{Agent: "codex"}, "x"); err == nil {
+		t.Fatal("want error when no binary resolved")
+	}
+}

--- a/server/internal/relay/waker_tmux.go
+++ b/server/internal/relay/waker_tmux.go
@@ -1,0 +1,54 @@
+package relay
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"os/exec"
+)
+
+// execRunner runs a command to completion; injectable so tests assert
+// the argument vector without spawning tmux.
+type execRunner func(ctx context.Context, name string, args ...string) error
+
+func defaultExecRunner(ctx context.Context, name string, args ...string) error {
+	return exec.CommandContext(ctx, name, args...).Run()
+}
+
+// TmuxWaker injects the prompt into a tmux pane via `send-keys`. This is
+// the most reliable waker on mac+linux: one implementation covers any
+// terminal emulator as long as the agent runs inside tmux.
+type TmuxWaker struct {
+	bin    string // resolved tmux path; "" when tmux isn't available
+	run    execRunner
+	logger *slog.Logger
+}
+
+func NewTmuxWaker(logger *slog.Logger) *TmuxWaker {
+	bin := os.Getenv("TMA1_TMUX_PATH")
+	if bin == "" {
+		if p, err := exec.LookPath("tmux"); err == nil {
+			bin = p
+		}
+	}
+	return &TmuxWaker{bin: bin, run: defaultExecRunner, logger: logger}
+}
+
+func (w *TmuxWaker) Name() string { return "tmux" }
+
+func (w *TmuxWaker) CanWake(t Target) bool {
+	return w.bin != "" && t.Terminals["tmux"] != ""
+}
+
+// Wake sends the prompt as a literal (-l) so tmux doesn't interpret a
+// ';' or an embedded key-name (e.g. "Enter", "C-c") inside the text,
+// then sends Enter as a separate key to submit it. The prompt is a
+// single exec argument (not a shell string), so there's no shell
+// injection surface.
+func (w *TmuxWaker) Wake(ctx context.Context, t Target, prompt string) error {
+	pane := t.Terminals["tmux"]
+	if err := w.run(ctx, w.bin, "send-keys", "-t", pane, "-l", "--", prompt); err != nil {
+		return err
+	}
+	return w.run(ctx, w.bin, "send-keys", "-t", pane, "Enter")
+}

--- a/server/internal/relay/waker_tmux.go
+++ b/server/internal/relay/waker_tmux.go
@@ -2,9 +2,11 @@ package relay
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"os"
 	"os/exec"
+	"sync/atomic"
 )
 
 // execRunner runs a command to completion; injectable so tests assert
@@ -40,14 +42,28 @@ func (w *TmuxWaker) CanWake(t Target) bool {
 	return w.bin != "" && t.Terminals["tmux"] != ""
 }
 
-// Wake sends the prompt as a literal (-l) so tmux doesn't interpret a
-// ';' or an embedded key-name (e.g. "Enter", "C-c") inside the text,
-// then sends Enter as a separate key to submit it. The prompt is a
-// single exec argument (not a shell string), so there's no shell
-// injection surface.
+// tmuxBufferSeq makes each Wake use a distinct paste-buffer name. A shared
+// fixed name would let two concurrent handoffs clobber each other's buffer
+// between set-buffer and paste-buffer (paste the wrong prompt into the
+// wrong pane). os.Getpid()+atomic counter is unique without a clock.
+var tmuxBufferSeq atomic.Uint64
+
+// Wake loads the prompt into a per-call buffer and pastes it with
+// bracketed paste (-p) keeping LF separators (-r), then submits with a
+// separate Enter. Unlike `send-keys -l`, paste-buffer -p makes tmux wrap
+// the text in bracketed-paste markers ONLY when the foreground app
+// requested that mode — so a multi-line prompt arrives as one block
+// instead of line-by-line, and a non-paste-aware program still gets clean
+// text. -r keeps embedded newlines as LF (default would rewrite them to CR
+// = submit). The prompt is sanitised so an embedded paste-end marker can't
+// close the bracket early. Each argument is a single exec arg (no shell).
 func (w *TmuxWaker) Wake(ctx context.Context, t Target, prompt string) error {
 	pane := t.Terminals["tmux"]
-	if err := w.run(ctx, w.bin, "send-keys", "-t", pane, "-l", "--", prompt); err != nil {
+	buf := fmt.Sprintf("tma1-relay-%d-%d", os.Getpid(), tmuxBufferSeq.Add(1))
+	if err := w.run(ctx, w.bin, "set-buffer", "-b", buf, "--", sanitizeForPaste(prompt)); err != nil {
+		return err
+	}
+	if err := w.run(ctx, w.bin, "paste-buffer", "-t", pane, "-b", buf, "-p", "-r", "-d"); err != nil {
 		return err
 	}
 	return w.run(ctx, w.bin, "send-keys", "-t", pane, "Enter")

--- a/server/internal/relay/waker_worker.go
+++ b/server/internal/relay/waker_worker.go
@@ -1,0 +1,91 @@
+package relay
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"os/exec"
+)
+
+// procStarter launches a detached command in dir and returns once it has
+// started (fire-and-forget). Injectable for tests.
+type procStarter func(dir, name string, args ...string) error
+
+func defaultProcStarter(dir, name string, args ...string) error {
+	cmd := exec.Command(name, args...)
+	cmd.Dir = dir
+	// Detach: the worker is a real agent run that must outlive the HTTP
+	// request that triggered it. setDetach sets a platform-appropriate
+	// process-group attribute so it survives the parent.
+	setDetach(cmd)
+	return cmd.Start()
+}
+
+// WorkerWaker is the universal fallback: when no interactive terminal can
+// be reached (no tmux pane, etc.), it spawns a fresh non-interactive
+// agent run in the target's CWD. Whether that run's hooks fire / MCP
+// loads (so the relay chain continues) is verified by a spike before
+// being relied on; until then this is best-effort.
+type WorkerWaker struct {
+	codexBin  string
+	claudeBin string
+	start     procStarter
+	logger    *slog.Logger
+}
+
+func NewWorkerWaker(logger *slog.Logger) *WorkerWaker {
+	return &WorkerWaker{
+		codexBin:  lookCmd("TMA1_CODEX_PATH", "codex"),
+		claudeBin: lookCmd("TMA1_CLAUDE_PATH", "claude"),
+		start:     defaultProcStarter,
+		logger:    logger,
+	}
+}
+
+func lookCmd(envKey, name string) string {
+	if v := os.Getenv(envKey); v != "" {
+		return v
+	}
+	if p, err := exec.LookPath(name); err == nil {
+		return p
+	}
+	return ""
+}
+
+func (w *WorkerWaker) Name() string { return "worker" }
+
+// CanWake is true only when the binary for the target's agent resolved.
+// If neither codex nor claude is on PATH there's nothing to spawn.
+func (w *WorkerWaker) CanWake(t Target) bool {
+	return w.binFor(t.Agent) != ""
+}
+
+func (w *WorkerWaker) binFor(agent string) string {
+	switch agent {
+	case "codex":
+		return w.codexBin
+	case "claude_code":
+		return w.claudeBin
+	default:
+		if w.codexBin != "" {
+			return w.codexBin
+		}
+		return w.claudeBin
+	}
+}
+
+// Wake spawns the agent in non-interactive mode with the prompt. It does
+// NOT thread ctx into the process: the HTTP handler returns in
+// milliseconds and cancelling ctx would kill the worker.
+func (w *WorkerWaker) Wake(_ context.Context, t Target, prompt string) error {
+	bin := w.binFor(t.Agent)
+	if bin == "" {
+		return errNoWorkerBin
+	}
+	// claude → `-p <prompt>`, codex → `exec <prompt>`.
+	args := []string{"exec", prompt}
+	if bin == w.claudeBin {
+		args = []string{"-p", prompt}
+	}
+	return w.start(t.CWD, bin, args...)
+}


### PR DESCRIPTION
## What

Automates the manual `/tma1-peer` ping-pong between two agent terminals. At a
workflow milestone the driver/reviewer calls the `tma1_handoff` MCP tool →
tma1-server wakes the **counterpart's** terminal with the next instruction,
carrying an inline summary so the peer needn't re-pull the session.

This closes the reverse direction TMA1 was missing: it was pure pull
(`get_peer_sessions`), with no way to actively nudge an idle terminal.

## How it fits

```
driver calls MCP tool tma1_handoff(stage, summary)   [in mcp-serve child]
  → POST 127.0.0.1:$TMA1_PORT/api/relay/signal  (X-Tma1-Relay-Token)
  → Coordinator: resolve project, look up transition, find counterpart target
  → Waker injects the next prompt into the counterpart's terminal
  → counterpart runs, calls tma1_handoff(next stage, summary) → wakes back
```

Two layers: a platform-agnostic per-project state machine (`internal/relay`),
and a pluggable `Waker` registry that delivers the prompt to a terminal.

## Phases in this PR

**Phase 1** — state machine (Register/Touch/Unregister lifecycle), hardcoded
4-stage transition table (plan_ready / plan_reviewed / impl_done /
code_reviewed), local token auth (`~/.tma1/relay_token`), token-gated
`POST /api/relay/signal` (4xx on bad input), the `tma1_handoff` MCP tool,
tmux + worker wakers, and terminal registration via `X-Tma1-Role` /
`X-Tma1-Terminal` hook headers.

**Phase 2** — visible wake on iTerm + multi-line safety:
- `itermWaker`: osascript locates the session by its `ITERM_SESSION_ID` UUID;
  the prompt is passed as osascript **argv** (never interpolated into the
  script), so there's no injection surface. is-processing busy gate; unknown
  session id falls through. Registry order is `tmux → iterm → worker`.
- tmux waker switched to a per-call paste buffer (`set-buffer` +
  `paste-buffer -p -r` + Enter): multi-line prompts arrive as one
  bracketed-paste block, and concurrent handoffs can't clobber a shared buffer.
- bracketed-paste wrap + sanitize, with a single-line fallback for REPLs that
  don't honour `ESC[?2004h`.

**Phase 3** — robustness:
- Busy-debounce: a woken role is reserved **under the lock** before the Wake,
  so concurrent signals can't double-wake (or spawn two workers); a re-signal
  to a pending role is dropped honestly with a retry hint. Pending clears on
  the peer's next signal, SessionEnd, a fresh SessionStart, or GC.
- Wake-timeout (`TMA1_RELAY_WAKE_TIMEOUT`, default 10m): nudge the originator
  if the peer never hands back. `Coordinator.Stop()` cancels timers on shutdown.
- Configurable transition table via `~/.tma1/relay.json`, merged onto the
  built-in defaults; the endpoint validates against the live table.

## Security / threat model

The signal endpoint injects terminal text and can spawn worker processes, so an
Origin check (which a non-browser caller doesn't send) is the wrong guard — it
uses a shared local token instead. The token is shared with MCP children via
installer-written env. Same-UID processes can read the token file, so this is
not a defense against a malicious local process; it guards against accidental
cross-tool POSTs. Forged-SessionStart override is mitigated by validating
target liveness before injecting (a dead/closed session id falls through).

New env: `TMA1_RELAY_WAKE_TIMEOUT`, `TMA1_RELAY_BRACKETED_PASTE`,
`TMA1_RELAY_ITERM_BUSY_GATE`, `TMA1_OSASCRIPT_PATH`, plus worker-binary path
overrides for launchd's narrow PATH.

## Verification

- `go vet ./...`, `go test -race -count=1 ./...`, `make build` — all pass.
- itermWaker injection proven end-to-end on real iTerm2 (argv + bracketed-paste
  bytes delivered to a throwaway session).
- Concurrency single-flight, busy-retry, wake-timeout, Stop, and
  register-clears-stale-pending are covered by `-race` tests.

## Deferred (not in this PR)

- Real two-pane end-to-end run and the worker-reflux spike need live agents.
- Whether the peer agent REPLs honour bracketed paste is covered by the
  single-line fallback if not.
- First-hop auto-trigger (the agent calling `tma1_handoff` itself) and
  kitty/wezterm wakers are follow-ups.

Docs: see the Relay section in `docs/architecture.md`.