### PR TITLE
fix: parse Codex hook transcript paths

### DIFF
--- a/server/internal/handler/handler_test.go
+++ b/server/internal/handler/handler_test.go
@@ -6,14 +6,19 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
+	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/tma1-ai/tma1/server/internal/perception"
+	"github.com/tma1-ai/tma1/server/internal/transcript"
 )
 
 // newTestServer returns a Server wired with greptimeHTTPPort=0 — the
@@ -488,6 +493,55 @@ func TestHooksEndpointValid(t *testing.T) {
 	}
 }
 
+func TestHooksCodexTranscriptPathUsesCodexParser(t *testing.T) {
+	dir := t.TempDir()
+	const conversationUUID = "019ee354-e4c9-7950-930c-8852ad802967"
+	transcriptPath := filepath.Join(dir, "rollout-2026-06-20T12-40-52-"+conversationUUID+".jsonl")
+	lines := []string{
+		`{"timestamp":"2026-06-20T12:40:52Z","type":"session_meta","payload":{"id":"` + conversationUUID + `","source":{"cli":"codex"},"cwd":"/tmp/project"}}`,
+		`{"timestamp":"2026-06-20T12:40:53Z","type":"event_msg","payload":{"type":"user_message","message":"hello from codex via transcript_path"}}`,
+	}
+	if err := os.WriteFile(transcriptPath, []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	sqlCh := make(chan string, 8)
+	fakeGreptime := httptest.NewServer(captureSQLHandler(sqlCh))
+	defer fakeGreptime.Close()
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	tw := transcript.NewWatcher(testHTTPServerPort(t, fakeGreptime.URL), logger, nil)
+	defer tw.StopAll()
+	srv := New(0, "14318", http.Dir("."), logger, tw, NewHookBroadcaster(), LLMConfig{}, ServerConfig{})
+	r := srv.Router()
+
+	payload, err := json.Marshal(map[string]string{
+		"session_id":      conversationUUID,
+		"hook_event_name": "SessionStart",
+		"cwd":             "/tmp/project",
+		"transcript_path": transcriptPath,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/api/hooks?source=codex", strings.NewReader(string(payload)))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+
+	sql := waitForCapturedSQLContaining(t, sqlCh,
+		"INSERT INTO tma1_messages",
+		conversationUUID,
+		"hello from codex via transcript_path",
+	)
+	if strings.Contains(sql, "rollout-2026-06-20T12-40-52") {
+		t.Fatalf("Codex hook transcript should use conversation UUID, got filename session id in SQL: %s", sql)
+	}
+}
+
 func TestHooksUserPromptSubmitGeneratesEmptyWhenNoData(t *testing.T) {
 	// Bundler runs against a non-existent GreptimeDB → BuildBundle returns an
 	// empty bundle → RenderSummary returns "". The endpoint must still 200.
@@ -859,6 +913,60 @@ func TestHooksEndpointMissingFields(t *testing.T) {
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+}
+
+func captureSQLHandler(sqlCh chan<- string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		sqlCh <- r.Form.Get("sql")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"output":[]}`))
+	}
+}
+
+func testHTTPServerPort(t *testing.T, rawURL string) int {
+	t.Helper()
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		t.Fatalf("parse test server URL: %v", err)
+	}
+	_, portText, err := net.SplitHostPort(u.Host)
+	if err != nil {
+		t.Fatalf("split test server host: %v", err)
+	}
+	port, err := strconv.Atoi(portText)
+	if err != nil {
+		t.Fatalf("parse test server port: %v", err)
+	}
+	return port
+}
+
+func waitForCapturedSQLContaining(t *testing.T, sqlCh <-chan string, wants ...string) string {
+	t.Helper()
+	timer := time.NewTimer(2 * time.Second)
+	defer timer.Stop()
+	var seen []string
+	for {
+		select {
+		case sql := <-sqlCh:
+			seen = append(seen, sql)
+			matches := true
+			for _, want := range wants {
+				if !strings.Contains(sql, want) {
+					matches = false
+					break
+				}
+			}
+			if matches {
+				return sql
+			}
+		case <-timer.C:
+			t.Fatalf("timed out waiting for SQL containing %q; seen %q", wants, seen)
+		}
 	}
 }
 

--- a/server/internal/handler/hooks.go
+++ b/server/internal/handler/hooks.go
@@ -225,7 +225,11 @@ func (s *Server) handleHooks(w http.ResponseWriter, r *http.Request) {
 
 	// Start transcript watcher on first event for this session.
 	if s.transcriptWatcher != nil && payload.TranscriptPath != "" {
-		s.transcriptWatcher.Watch(payload.SessionID, payload.TranscriptPath)
+		if agentSource == "codex" {
+			s.transcriptWatcher.WatchCodex(payload.SessionID, payload.TranscriptPath)
+		} else {
+			s.transcriptWatcher.Watch(payload.SessionID, payload.TranscriptPath)
+		}
 	}
 
 	// Stop transcript watcher on session end.
@@ -234,7 +238,11 @@ func (s *Server) handleHooks(w http.ResponseWriter, r *http.Request) {
 		// Delay slightly to let final JSONL lines flush.
 		go func() {
 			time.Sleep(2 * time.Second)
-			s.transcriptWatcher.Stop(payload.SessionID)
+			if agentSource == "codex" && payload.TranscriptPath != "" {
+				s.transcriptWatcher.StopCodex(payload.TranscriptPath)
+			} else {
+				s.transcriptWatcher.Stop(payload.SessionID)
+			}
 		}()
 	}
 

--- a/server/internal/transcript/codex.go
+++ b/server/internal/transcript/codex.go
@@ -33,8 +33,8 @@ const (
 )
 
 // StartCodexScanner periodically scans ~/.codex/sessions/ for active JSONL files
-// and starts watching any new ones. Codex doesn't send hooks, so we discover
-// session files by polling the filesystem.
+// and starts watching any new ones. This remains a fallback/backfill path for
+// Codex sessions that are not surfaced through hooks.
 func (w *Watcher) StartCodexScanner(ctx context.Context) {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
@@ -140,6 +140,42 @@ func (w *Watcher) scanCodexSessions(baseDir string) {
 			w.watchCodex(p.watcherKey, p.sessionID, p.filePath)
 		}
 	}
+}
+
+// WatchCodex starts tailing a specific Codex JSONL transcript path reported by
+// a Codex hook. Unlike Watch, this routes lines through the Codex rollout parser
+// instead of the Claude Code transcript parser.
+func (w *Watcher) WatchCodex(sessionID, transcriptPath string) {
+	watcherKey, parserSessionID := codexWatcherIdentity(transcriptPath)
+	if watcherKey == "" {
+		return
+	}
+	if parserSessionID == "" {
+		parserSessionID = sessionID
+	}
+	if uuid, isMain := peekCodexMainUUID(transcriptPath); isMain && uuid != "" {
+		w.recordCodexParentSession(parserSessionID, uuid)
+	}
+	w.watchCodex(watcherKey, parserSessionID, transcriptPath)
+}
+
+// StopCodex stops a Codex transcript watcher previously started for a concrete
+// transcript path. Codex watchers are keyed by rollout filename so they dedupe
+// with the ~/.codex scanner, not by hook session_id.
+func (w *Watcher) StopCodex(transcriptPath string) {
+	watcherKey, _ := codexWatcherIdentity(transcriptPath)
+	if watcherKey == "" {
+		return
+	}
+	w.Stop(watcherKey)
+}
+
+func codexWatcherIdentity(transcriptPath string) (watcherKey, parserSessionID string) {
+	baseName := strings.TrimSuffix(filepath.Base(transcriptPath), ".jsonl")
+	if baseName == "" || baseName == "." || baseName == string(filepath.Separator) {
+		return "", ""
+	}
+	return "codex:" + baseName, codexSessionGroup(baseName)
 }
 
 // peekCodexMainUUID opens a Codex rollout file, reads only the first

--- a/server/internal/transcript/codex.go
+++ b/server/internal/transcript/codex.go
@@ -162,12 +162,27 @@ func (w *Watcher) WatchCodex(sessionID, transcriptPath string) {
 // StopCodex stops a Codex transcript watcher previously started for a concrete
 // transcript path. Codex watchers are keyed by rollout filename so they dedupe
 // with the ~/.codex scanner, not by hook session_id.
+//
+// Unlike Watch/Stop, this cancels the tail goroutine WITHOUT deleting the
+// session entry, so its `seen` map survives. The rollout file stays "active"
+// for codexActiveAge after the Stop hook, so the ~/.codex scanner re-attaches
+// via watchCodex and reuses the preserved map. Deleting the entry (as w.Stop
+// does) would force a from-scratch re-read and emit duplicate rows into the
+// append-mode tma1_messages / tma1_hook_events tables. The tail goroutine's
+// defer marks the entry stopped on exit, allowing the restart.
 func (w *Watcher) StopCodex(transcriptPath string) {
 	watcherKey, _ := codexWatcherIdentity(transcriptPath)
 	if watcherKey == "" {
 		return
 	}
-	w.Stop(watcherKey)
+	w.mu.Lock()
+	sw, ok := w.sessions[watcherKey]
+	w.mu.Unlock()
+	if !ok {
+		return
+	}
+	sw.cancel()
+	w.logger.Info("stopped watching codex session", "file", transcriptPath)
 }
 
 func codexWatcherIdentity(transcriptPath string) (watcherKey, parserSessionID string) {


### PR DESCRIPTION
## Summary
- Route Codex hook-provided `transcript_path` through the Codex rollout JSONL parser instead of the generic transcript parser.
- Add Codex-specific watcher start/stop helpers that share watcher keys with the `~/.codex/sessions` scanner for dedupe.
- Cover the hook path with a regression test that posts a Codex hook and captures the resulting Greptime SQL insert.

## Test plan
- `go test ./internal/handler -run TestHooksCodexTranscriptPathUsesCodexParser -count=1 -v`
- `go test ./internal/transcript -run 'TestCodex|TestProcessCodex' -count=1`
- `go test ./...`
- `make build`
- `make test`
- Local daemon validation: posting an Orca-managed Codex `transcript_path` for session `019ee354...2967` populated `tma1_messages` from 0 to 117 rows.