### PR TITLE
feat(tma1-peer): make message_limit a 3rd arg, default 10

### DIFF
--- a/claude-plugin/codex-skills/tma1-peer/SKILL.md
+++ b/claude-plugin/codex-skills/tma1-peer/SKILL.md
@@ -18,13 +18,13 @@ output on the current project, or when they explicitly type
 
 - First positional arg (optional): peer agent name (`claude` / `claude_code`
   / `openclaw` / `copilot` / `copilot_cli` / `all`). **If this arg is a bare
-  integer** (e.g. `/tma1-peer 3`), it is the count, not an agent — use
-  `agent_source: ""` (all peers) and that integer as the count. Do not reject
-  it as an unknown agent.
-- Second positional arg (optional): count of recent sessions to pull,
-  integer 1-5, default 1.
-- Third positional arg (optional): messages per session to pull,
-  integer 1-100, default 10.
+  integer** (e.g. `/tma1-peer 3`), there's no agent token: it is the count, and
+  the next integer (if any) is messages per session — use `agent_source: ""`
+  (all peers). Do not reject it as an unknown agent. E.g. `/tma1-peer 3 30` →
+  count 3, 30 messages.
+- Count (first integer, after the agent name when present): recent sessions to
+  pull, integer 1-5, default 1.
+- Messages per session (the integer after count): integer 1-100, default 10.
 
 If none is supplied, treat as `all` with count 1 and 10 messages.
 

--- a/claude-plugin/codex-skills/tma1-peer/SKILL.md
+++ b/claude-plugin/codex-skills/tma1-peer/SKILL.md
@@ -14,7 +14,7 @@ work without copy-pasting it manually.
 
 This skill is auto-selected when the user mentions reading another agent's
 output on the current project, or when they explicitly type
-`/tma1-peer [agent] [count]`. Parse:
+`/tma1-peer [agent] [count] [messages]`. Parse:
 
 - First positional arg (optional): peer agent name (`claude` / `claude_code`
   / `openclaw` / `copilot` / `copilot_cli` / `all`). **If this arg is a bare
@@ -23,8 +23,10 @@ output on the current project, or when they explicitly type
   it as an unknown agent.
 - Second positional arg (optional): count of recent sessions to pull,
   integer 1-5, default 1.
+- Third positional arg (optional): messages per session to pull,
+  integer 1-100, default 10.
 
-If neither is supplied, treat as `all` with count 1.
+If none is supplied, treat as `all` with count 1 and 10 messages.
 
 ## Normalize the agent name
 
@@ -50,7 +52,7 @@ the `get_peer_sessions` tool on that server with:
 | --------------- | ------------------------------------------------------ |
 | `agent_source`  | the canonical name from the table above (or `""`)      |
 | `limit`         | the parsed count — **when the user gave a count you MUST pass it** (don't default to 1); omit only when none was given (server default `1`, clamp `[1, 5]`) |
-| `message_limit` | `30`                                                   |
+| `message_limit` | the parsed third arg if supplied (clamp `[1, 100]`), otherwise `10` |
 
 If your runtime addresses MCP tools by a prefixed name (for example
 `tma1.get_peer_sessions` or `mcp_tma1_get_peer_sessions`), use whichever
@@ -95,7 +97,7 @@ quote the failed agent(s) instead of asserting silence.
 ## Examples
 
 User: "what did claude leave on this project?"
-You: (call `get_peer_sessions` with `agent_source: "claude_code", limit: 1, message_limit: 30`)
+You: (call `get_peer_sessions` with `agent_source: "claude_code", limit: 1, message_limit: 10`)
 You: "Claude Code reviewed `server/internal/handler/anomalies.go` 8 minutes ago and flagged three concrete issues:
 1. fetchEmits has no LIMIT — body cap will truncate before the query finishes.
 2. `applyForceColor` env dedup is libc-dependent.
@@ -103,7 +105,7 @@ You: "Claude Code reviewed `server/internal/handler/anomalies.go` 8 minutes ago 
 Want me to address all three or pick one?"
 
 User: `/tma1-peer copilot 2`
-You: (call `get_peer_sessions` with `agent_source: "copilot_cli", limit: 2, message_limit: 30`)
+You: (call `get_peer_sessions` with `agent_source: "copilot_cli", limit: 2, message_limit: 10`)
 You: "Copilot CLI ran two sessions on this project today — the most recent
 deployed staging 20 min ago (success), the prior one 2 h ago ran the
 test suite and hit a flake in `TestSemAcceptsUpToCapacity`."

--- a/claude-plugin/commands/tma1-peer.md
+++ b/claude-plugin/commands/tma1-peer.md
@@ -1,6 +1,6 @@
 ---
 description: Pull recent session content from peer coding agents (Codex, OpenClaw, Copilot CLI) that worked on this project.
-argument-hint: "[agent] [count]"
+argument-hint: "[agent] [count] [messages]"
 allowed-tools: ["mcp__tma1__get_peer_sessions"]
 ---
 
@@ -20,7 +20,8 @@ file carries the essential rules for the explicit-invocation path.
   - **a bare integer** (e.g. `/tma1-peer 3`) → it's the count, not an agent: use
     `agent_source: ""` and that integer as the count. Do **not** reject it.
   - **Anything else** → reply `unknown peer agent "<X>"; available: codex, openclaw, copilot, all` and **STOP**.
-- 2nd token (optional) → integer, default `1`, clamped to `[1, 5]` server-side.
+- 2nd token (optional) → count, integer, default `1`, clamped to `[1, 5]` server-side.
+- 3rd token (optional) → messages per session, integer, default `10`, clamp `[1, 100]`.
 
 ## Call the tool
 
@@ -28,7 +29,8 @@ file carries the essential rules for the explicit-invocation path.
 - `agent_source`: the normalized name (or `""`)
 - `limit`: parsed count — **when a count was given, you MUST pass it** (don't
   silently default to 1); e.g. `codex 3` → `limit: 3`
-- `message_limit`: `30`
+- `message_limit`: parsed 3rd token if supplied (clamp `[1, 100]`), else `10`;
+  e.g. `codex 3 30` → `message_limit: 30`
 
 ## Use the response
 

--- a/claude-plugin/commands/tma1-peer.md
+++ b/claude-plugin/commands/tma1-peer.md
@@ -17,11 +17,13 @@ file carries the essential rules for the explicit-invocation path.
   - `openclaw` → `openclaw`
   - `copilot` / `copilot_cli` → `copilot_cli`
   - `all` / `*` / empty → `""` (all peers, server excludes the caller)
-  - **a bare integer** (e.g. `/tma1-peer 3`) → it's the count, not an agent: use
-    `agent_source: ""` and that integer as the count. Do **not** reject it.
+  - **a bare integer** (e.g. `/tma1-peer 3`) → there's no agent token: this
+    integer is the count and the *next* integer (if any) is messages per session.
+    Use `agent_source: ""`. Do **not** reject it. E.g. `/tma1-peer 3 30` → count
+    3, 30 messages.
   - **Anything else** → reply `unknown peer agent "<X>"; available: codex, openclaw, copilot, all` and **STOP**.
-- 2nd token (optional) → count, integer, default `1`, clamped to `[1, 5]` server-side.
-- 3rd token (optional) → messages per session, integer, default `10`, clamp `[1, 100]`.
+- Count (the first integer, after the agent token when present) → default `1`, clamp `[1, 5]` server-side.
+- Messages per session (the integer after count) → default `10`, clamp `[1, 100]`.
 
 ## Call the tool
 

--- a/claude-plugin/skills/tma1-peer/SKILL.md
+++ b/claude-plugin/skills/tma1-peer/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: tma1-peer
 description: "Pull recent session content from peer coding agents (Codex, OpenClaw, Copilot CLI) that worked on the same project. Invoke when the user wants you to read another agent's review feedback, see what someone else tried, or act on cross-agent context. Trigger phrases: \"what did codex do\", \"what did openclaw do\", \"what did copilot do\", \"peer sessions\", \"cross-agent context\", \"/tma1-peer\"."
-argument-hint: "[agent] [count]"
+argument-hint: "[agent] [count] [messages]"
 allowed-tools: ["mcp__tma1__get_peer_sessions"]
 ---
 
@@ -15,9 +15,10 @@ copy-pasting it manually.
 ## Syntax
 
 ```
-/tma1-peer                 # all peers, latest 1 session each
+/tma1-peer                 # all peers, latest 1 session each, 10 messages
 /tma1-peer codex           # codex, latest 1 session
 /tma1-peer codex 3         # codex, latest 3 sessions
+/tma1-peer codex 3 30      # codex, latest 3 sessions, 30 messages each
 /tma1-peer openclaw        # openclaw, latest 1
 /tma1-peer copilot 2       # copilot_cli (alias), latest 2
 /tma1-peer all 2           # all peers, 2 each
@@ -31,6 +32,7 @@ copy-pasting it manually.
      count, not an agent — use `agent_source: ""` (all peers) and that integer
      as the count. Do NOT reject it as an unknown agent.
    - Second token (optional): count (integer 1-5).
+   - Third token (optional): messages per session (integer 1-100, default 10).
 2. **Normalize the agent name**:
    - `codex` → `codex`
    - `openclaw` → `openclaw`
@@ -43,7 +45,8 @@ copy-pasting it manually.
    - `limit`: the parsed count. **When the user gave a count, you MUST pass it**
      — do not silently fall back to 1. Omit only when no count was supplied
      (server default 1, clamp to [1, 5]). E.g. `codex 3` → `{agent_source: "codex", limit: 3}`.
-   - `message_limit`: 30
+   - `message_limit`: the parsed third token if supplied (clamp to [1, 100]),
+     otherwise `10`. E.g. `codex 3 30` → `{agent_source: "codex", limit: 3, message_limit: 30}`.
 4. **Read the returned conversation messages** and use them as direct input
    for your next reasoning step. **Do not paraphrase** — when acting on
    peer feedback, quote the specific points the peer made so the user can
@@ -76,7 +79,7 @@ this project" rather than fabricating context.
 ## Examples
 
 User: `/tma1-peer codex`
-You: (call tool with `agent_source: "codex", limit: 1, message_limit: 30`)
+You: (call tool with `agent_source: "codex", limit: 1, message_limit: 10`)
 You: "Codex reviewed `auth.go` 12 min ago and left three concrete issues:
      1. ... 2. ... 3. ... Want me to address all three or pick one?"
 

--- a/claude-plugin/skills/tma1-peer/SKILL.md
+++ b/claude-plugin/skills/tma1-peer/SKILL.md
@@ -28,11 +28,12 @@ copy-pasting it manually.
 
 1. **Parse the user's arguments** after `/tma1-peer`:
    - First token (optional): agent name.
-   - **If the first token is a bare integer** (e.g. `/tma1-peer 3`), it is the
-     count, not an agent — use `agent_source: ""` (all peers) and that integer
-     as the count. Do NOT reject it as an unknown agent.
-   - Second token (optional): count (integer 1-5).
-   - Third token (optional): messages per session (integer 1-100, default 10).
+   - **If the first token is a bare integer** (e.g. `/tma1-peer 3`), there's no
+     agent token: it is the count, and the next integer (if any) is messages
+     per session — use `agent_source: ""` (all peers). Do NOT reject it as an
+     unknown agent. E.g. `/tma1-peer 3 30` → count 3, 30 messages.
+   - Count (first integer, after the agent token when present): integer 1-5, default 1.
+   - Messages per session (the integer after count): integer 1-100, default 10.
 2. **Normalize the agent name**:
    - `codex` → `codex`
    - `openclaw` → `openclaw`

--- a/server/internal/hooks/codex-skills/tma1-peer/SKILL.md
+++ b/server/internal/hooks/codex-skills/tma1-peer/SKILL.md
@@ -18,13 +18,13 @@ output on the current project, or when they explicitly type
 
 - First positional arg (optional): peer agent name (`claude` / `claude_code`
   / `openclaw` / `copilot` / `copilot_cli` / `all`). **If this arg is a bare
-  integer** (e.g. `/tma1-peer 3`), it is the count, not an agent — use
-  `agent_source: ""` (all peers) and that integer as the count. Do not reject
-  it as an unknown agent.
-- Second positional arg (optional): count of recent sessions to pull,
-  integer 1-5, default 1.
-- Third positional arg (optional): messages per session to pull,
-  integer 1-100, default 10.
+  integer** (e.g. `/tma1-peer 3`), there's no agent token: it is the count, and
+  the next integer (if any) is messages per session — use `agent_source: ""`
+  (all peers). Do not reject it as an unknown agent. E.g. `/tma1-peer 3 30` →
+  count 3, 30 messages.
+- Count (first integer, after the agent name when present): recent sessions to
+  pull, integer 1-5, default 1.
+- Messages per session (the integer after count): integer 1-100, default 10.
 
 If none is supplied, treat as `all` with count 1 and 10 messages.
 

--- a/server/internal/hooks/codex-skills/tma1-peer/SKILL.md
+++ b/server/internal/hooks/codex-skills/tma1-peer/SKILL.md
@@ -14,7 +14,7 @@ work without copy-pasting it manually.
 
 This skill is auto-selected when the user mentions reading another agent's
 output on the current project, or when they explicitly type
-`/tma1-peer [agent] [count]`. Parse:
+`/tma1-peer [agent] [count] [messages]`. Parse:
 
 - First positional arg (optional): peer agent name (`claude` / `claude_code`
   / `openclaw` / `copilot` / `copilot_cli` / `all`). **If this arg is a bare
@@ -23,8 +23,10 @@ output on the current project, or when they explicitly type
   it as an unknown agent.
 - Second positional arg (optional): count of recent sessions to pull,
   integer 1-5, default 1.
+- Third positional arg (optional): messages per session to pull,
+  integer 1-100, default 10.
 
-If neither is supplied, treat as `all` with count 1.
+If none is supplied, treat as `all` with count 1 and 10 messages.
 
 ## Normalize the agent name
 
@@ -50,7 +52,7 @@ the `get_peer_sessions` tool on that server with:
 | --------------- | ------------------------------------------------------ |
 | `agent_source`  | the canonical name from the table above (or `""`)      |
 | `limit`         | the parsed count — **when the user gave a count you MUST pass it** (don't default to 1); omit only when none was given (server default `1`, clamp `[1, 5]`) |
-| `message_limit` | `30`                                                   |
+| `message_limit` | the parsed third arg if supplied (clamp `[1, 100]`), otherwise `10` |
 
 If your runtime addresses MCP tools by a prefixed name (for example
 `tma1.get_peer_sessions` or `mcp_tma1_get_peer_sessions`), use whichever
@@ -95,7 +97,7 @@ quote the failed agent(s) instead of asserting silence.
 ## Examples
 
 User: "what did claude leave on this project?"
-You: (call `get_peer_sessions` with `agent_source: "claude_code", limit: 1, message_limit: 30`)
+You: (call `get_peer_sessions` with `agent_source: "claude_code", limit: 1, message_limit: 10`)
 You: "Claude Code reviewed `server/internal/handler/anomalies.go` 8 minutes ago and flagged three concrete issues:
 1. fetchEmits has no LIMIT — body cap will truncate before the query finishes.
 2. `applyForceColor` env dedup is libc-dependent.
@@ -103,7 +105,7 @@ You: "Claude Code reviewed `server/internal/handler/anomalies.go` 8 minutes ago 
 Want me to address all three or pick one?"
 
 User: `/tma1-peer copilot 2`
-You: (call `get_peer_sessions` with `agent_source: "copilot_cli", limit: 2, message_limit: 30`)
+You: (call `get_peer_sessions` with `agent_source: "copilot_cli", limit: 2, message_limit: 10`)
 You: "Copilot CLI ran two sessions on this project today — the most recent
 deployed staging 20 min ago (success), the prior one 2 h ago ran the
 test suite and hit a flake in `TestSemAcceptsUpToCapacity`."

--- a/server/internal/hooks/commands/tma1-peer.md
+++ b/server/internal/hooks/commands/tma1-peer.md
@@ -1,6 +1,6 @@
 ---
 description: Pull recent session content from peer coding agents (Codex, OpenClaw, Copilot CLI) that worked on this project.
-argument-hint: "[agent] [count]"
+argument-hint: "[agent] [count] [messages]"
 allowed-tools: ["mcp__tma1__get_peer_sessions"]
 ---
 
@@ -20,7 +20,8 @@ file carries the essential rules for the explicit-invocation path.
   - **a bare integer** (e.g. `/tma1-peer 3`) → it's the count, not an agent: use
     `agent_source: ""` and that integer as the count. Do **not** reject it.
   - **Anything else** → reply `unknown peer agent "<X>"; available: codex, openclaw, copilot, all` and **STOP**.
-- 2nd token (optional) → integer, default `1`, clamped to `[1, 5]` server-side.
+- 2nd token (optional) → count, integer, default `1`, clamped to `[1, 5]` server-side.
+- 3rd token (optional) → messages per session, integer, default `10`, clamp `[1, 100]`.
 
 ## Call the tool
 
@@ -28,7 +29,8 @@ file carries the essential rules for the explicit-invocation path.
 - `agent_source`: the normalized name (or `""`)
 - `limit`: parsed count — **when a count was given, you MUST pass it** (don't
   silently default to 1); e.g. `codex 3` → `limit: 3`
-- `message_limit`: `30`
+- `message_limit`: parsed 3rd token if supplied (clamp `[1, 100]`), else `10`;
+  e.g. `codex 3 30` → `message_limit: 30`
 
 ## Use the response
 

--- a/server/internal/hooks/commands/tma1-peer.md
+++ b/server/internal/hooks/commands/tma1-peer.md
@@ -17,11 +17,13 @@ file carries the essential rules for the explicit-invocation path.
   - `openclaw` → `openclaw`
   - `copilot` / `copilot_cli` → `copilot_cli`
   - `all` / `*` / empty → `""` (all peers, server excludes the caller)
-  - **a bare integer** (e.g. `/tma1-peer 3`) → it's the count, not an agent: use
-    `agent_source: ""` and that integer as the count. Do **not** reject it.
+  - **a bare integer** (e.g. `/tma1-peer 3`) → there's no agent token: this
+    integer is the count and the *next* integer (if any) is messages per session.
+    Use `agent_source: ""`. Do **not** reject it. E.g. `/tma1-peer 3 30` → count
+    3, 30 messages.
   - **Anything else** → reply `unknown peer agent "<X>"; available: codex, openclaw, copilot, all` and **STOP**.
-- 2nd token (optional) → count, integer, default `1`, clamped to `[1, 5]` server-side.
-- 3rd token (optional) → messages per session, integer, default `10`, clamp `[1, 100]`.
+- Count (the first integer, after the agent token when present) → default `1`, clamp `[1, 5]` server-side.
+- Messages per session (the integer after count) → default `10`, clamp `[1, 100]`.
 
 ## Call the tool
 

--- a/server/internal/hooks/skills/tma1-peer/SKILL.md
+++ b/server/internal/hooks/skills/tma1-peer/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: tma1-peer
 description: "Pull recent session content from peer coding agents (Codex, OpenClaw, Copilot CLI) that worked on the same project. Invoke when the user wants you to read another agent's review feedback, see what someone else tried, or act on cross-agent context. Trigger phrases: \"what did codex do\", \"what did openclaw do\", \"what did copilot do\", \"peer sessions\", \"cross-agent context\", \"/tma1-peer\"."
-argument-hint: "[agent] [count]"
+argument-hint: "[agent] [count] [messages]"
 allowed-tools: ["mcp__tma1__get_peer_sessions"]
 ---
 
@@ -15,9 +15,10 @@ copy-pasting it manually.
 ## Syntax
 
 ```
-/tma1-peer                 # all peers, latest 1 session each
+/tma1-peer                 # all peers, latest 1 session each, 10 messages
 /tma1-peer codex           # codex, latest 1 session
 /tma1-peer codex 3         # codex, latest 3 sessions
+/tma1-peer codex 3 30      # codex, latest 3 sessions, 30 messages each
 /tma1-peer openclaw        # openclaw, latest 1
 /tma1-peer copilot 2       # copilot_cli (alias), latest 2
 /tma1-peer all 2           # all peers, 2 each
@@ -31,6 +32,7 @@ copy-pasting it manually.
      count, not an agent — use `agent_source: ""` (all peers) and that integer
      as the count. Do NOT reject it as an unknown agent.
    - Second token (optional): count (integer 1-5).
+   - Third token (optional): messages per session (integer 1-100, default 10).
 2. **Normalize the agent name**:
    - `codex` → `codex`
    - `openclaw` → `openclaw`
@@ -43,7 +45,8 @@ copy-pasting it manually.
    - `limit`: the parsed count. **When the user gave a count, you MUST pass it**
      — do not silently fall back to 1. Omit only when no count was supplied
      (server default 1, clamp to [1, 5]). E.g. `codex 3` → `{agent_source: "codex", limit: 3}`.
-   - `message_limit`: 30
+   - `message_limit`: the parsed third token if supplied (clamp to [1, 100]),
+     otherwise `10`. E.g. `codex 3 30` → `{agent_source: "codex", limit: 3, message_limit: 30}`.
 4. **Read the returned conversation messages** and use them as direct input
    for your next reasoning step. **Do not paraphrase** — when acting on
    peer feedback, quote the specific points the peer made so the user can
@@ -76,7 +79,7 @@ this project" rather than fabricating context.
 ## Examples
 
 User: `/tma1-peer codex`
-You: (call tool with `agent_source: "codex", limit: 1, message_limit: 30`)
+You: (call tool with `agent_source: "codex", limit: 1, message_limit: 10`)
 You: "Codex reviewed `auth.go` 12 min ago and left three concrete issues:
      1. ... 2. ... 3. ... Want me to address all three or pick one?"
 

--- a/server/internal/hooks/skills/tma1-peer/SKILL.md
+++ b/server/internal/hooks/skills/tma1-peer/SKILL.md
@@ -28,11 +28,12 @@ copy-pasting it manually.
 
 1. **Parse the user's arguments** after `/tma1-peer`:
    - First token (optional): agent name.
-   - **If the first token is a bare integer** (e.g. `/tma1-peer 3`), it is the
-     count, not an agent — use `agent_source: ""` (all peers) and that integer
-     as the count. Do NOT reject it as an unknown agent.
-   - Second token (optional): count (integer 1-5).
-   - Third token (optional): messages per session (integer 1-100, default 10).
+   - **If the first token is a bare integer** (e.g. `/tma1-peer 3`), there's no
+     agent token: it is the count, and the next integer (if any) is messages
+     per session — use `agent_source: ""` (all peers). Do NOT reject it as an
+     unknown agent. E.g. `/tma1-peer 3 30` → count 3, 30 messages.
+   - Count (first integer, after the agent token when present): integer 1-5, default 1.
+   - Messages per session (the integer after count): integer 1-100, default 10.
 2. **Normalize the agent name**:
    - `codex` → `codex`
    - `openclaw` → `openclaw`


### PR DESCRIPTION
## What

`tma1-peer` hardcoded `message_limit: 30` in the skill, command, and Codex
skill — larger than the MCP tool's own default (20) and not user-tunable.
Pulling 30 messages per session floods the agent's context.

## Change

- Expose messages-per-session as an optional **3rd positional arg** (`[messages]`, range 1-100).
- Drop the default from 30 to **10**.
- Applied across all three sources: Claude Code skill, Codex skill, slash command.
- Mirrored to the `go:embed` tree via `make sync-plugin`.

## Usage

```
/tma1-peer codex          # 10 messages/session (new default)
/tma1-peer codex 3 30     # 3 sessions, 30 messages each
```

`docs/mcp-tools.md` left unchanged — its `20` is the MCP tool's own default; the skill now always passes an explicit value.

## Note

Embedded content is fixed at compile time (`go:embed`); a running server picks this up after `make build`.