### PR TITLE
fix(install): resumable GreptimeDB download instead of restart-from-zero

### DIFF
--- a/server/internal/install/download_resumable_test.go
+++ b/server/internal/install/download_resumable_test.go
@@ -1,0 +1,163 @@
+package install
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+)
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelError}))
+}
+
+// rangeHandler serves payload with HTTP Range support. When interruptFirstAt>0
+// the very first request writes only that many body bytes and then aborts the
+// connection, simulating a mid-stream network cut so a later request must
+// resume.
+func rangeHandler(payload []byte, interruptFirstAt int) http.HandlerFunc {
+	var calls int32
+	return func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&calls, 1)
+
+		start := 0
+		if rng := r.Header.Get("Range"); rng != "" {
+			if _, err := fmt.Sscanf(rng, "bytes=%d-", &start); err != nil {
+				start = 0
+			}
+			if start >= len(payload) {
+				w.WriteHeader(http.StatusRequestedRangeNotSatisfiable)
+				return
+			}
+			w.Header().Set("Content-Range",
+				fmt.Sprintf("bytes %d-%d/%d", start, len(payload)-1, len(payload)))
+			w.WriteHeader(http.StatusPartialContent)
+		} else {
+			w.WriteHeader(http.StatusOK)
+		}
+
+		body := payload[start:]
+		if interruptFirstAt > 0 && n == 1 {
+			cut := interruptFirstAt
+			if cut > len(body) {
+				cut = len(body)
+			}
+			_, _ = w.Write(body[:cut])
+			if f, ok := w.(http.Flusher); ok {
+				f.Flush()
+			}
+			panic(http.ErrAbortHandler) // drop the connection mid-stream
+		}
+		_, _ = w.Write(body)
+	}
+}
+
+func TestDownloadFileResumable_Fresh(t *testing.T) {
+	payload := bytes.Repeat([]byte("greptime"), 1000) // 8000 bytes
+	srv := httptest.NewServer(rangeHandler(payload, 0))
+	defer srv.Close()
+
+	dst := filepath.Join(t.TempDir(), "greptime.tar.gz.partial")
+	if err := downloadFileResumable(dst, srv.URL, discardLogger()); err != nil {
+		t.Fatalf("fresh download: %v", err)
+	}
+
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Fatalf("content mismatch: got %d bytes, want %d", len(got), len(payload))
+	}
+}
+
+func TestDownloadFileResumable_Resumes(t *testing.T) {
+	payload := bytes.Repeat([]byte("greptime"), 1000) // 8000 bytes
+	cut := 3000
+	srv := httptest.NewServer(rangeHandler(payload, cut))
+	defer srv.Close()
+
+	dst := filepath.Join(t.TempDir(), "greptime.tar.gz.partial")
+	logger := discardLogger()
+
+	// First attempt is interrupted mid-stream — it must error but leave the
+	// bytes it managed to write on disk for the next attempt to resume from.
+	if err := downloadFileResumable(dst, srv.URL, logger); err == nil {
+		t.Fatal("expected first (interrupted) attempt to fail")
+	}
+	fi, err := os.Stat(dst)
+	if err != nil {
+		t.Fatalf("partial file should exist after interruption: %v", err)
+	}
+	if fi.Size() == 0 || fi.Size() >= int64(len(payload)) {
+		t.Fatalf("partial size = %d, want a partial 0 < n < %d", fi.Size(), len(payload))
+	}
+
+	// Second attempt resumes via Range and completes the file.
+	if err := downloadFileResumable(dst, srv.URL, logger); err != nil {
+		t.Fatalf("resume: %v", err)
+	}
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Fatalf("resumed content mismatch: got %d bytes, want %d", len(got), len(payload))
+	}
+}
+
+func TestDownloadFileResumable_ServerIgnoresRange(t *testing.T) {
+	payload := bytes.Repeat([]byte("greptime"), 1000)
+	// Server always returns 200 with the full body, ignoring the Range header.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(payload)
+	}))
+	defer srv.Close()
+
+	dst := filepath.Join(t.TempDir(), "greptime.tar.gz.partial")
+	// Seed a stale partial that must NOT be appended onto.
+	if err := os.WriteFile(dst, bytes.Repeat([]byte("stale"), 200), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := downloadFileResumable(dst, srv.URL, discardLogger()); err != nil {
+		t.Fatalf("download: %v", err)
+	}
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Fatalf("stale partial was not discarded on 200: got %d bytes, want %d", len(got), len(payload))
+	}
+}
+
+func TestDownloadFileResumable_AlreadyComplete(t *testing.T) {
+	payload := bytes.Repeat([]byte("greptime"), 1000)
+	srv := httptest.NewServer(rangeHandler(payload, 0))
+	defer srv.Close()
+
+	dst := filepath.Join(t.TempDir(), "greptime.tar.gz.partial")
+	// Partial already holds the whole asset → server answers 416 → no-op.
+	if err := os.WriteFile(dst, payload, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := downloadFileResumable(dst, srv.URL, discardLogger()); err != nil {
+		t.Fatalf("already-complete download should be a no-op, got: %v", err)
+	}
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Fatal("complete file should be left untouched")
+	}
+}

--- a/server/internal/install/install.go
+++ b/server/internal/install/install.go
@@ -41,8 +41,16 @@ func greptimeBinaryName() string {
 }
 
 var (
-	versionClient  = &http.Client{Timeout: 10 * time.Second}
-	downloadClient = &http.Client{Timeout: 5 * time.Minute}
+	versionClient = &http.Client{Timeout: 10 * time.Second}
+	// downloadClient has no overall timeout on purpose: the GreptimeDB binary
+	// is large (>150 MB) and on a slow link a legitimate, still-progressing
+	// transfer can run for many minutes — a wall-clock Client.Timeout would
+	// guillotine io.Copy mid-stream and loop forever. ResponseHeaderTimeout
+	// bounds the connect/header phase so a dead endpoint still fails fast, and
+	// downloadFileResumable covers any interrupted body read by resuming.
+	downloadClient = &http.Client{
+		Transport: &http.Transport{ResponseHeaderTimeout: 60 * time.Second},
+	}
 )
 
 // EnsureGreptimeDB checks whether the GreptimeDB binary exists in dataDir/bin/.
@@ -89,14 +97,14 @@ func EnsureGreptimeDB(dataDir, version string, logger *slog.Logger) (binPath str
 		return "", err
 	}
 
-	tmpFile, err := os.CreateTemp("", "greptime-*.tar.gz")
-	if err != nil {
-		return "", fmt.Errorf("install: create temp file: %w", err)
-	}
-	defer os.Remove(tmpFile.Name())
-	defer tmpFile.Close()
+	// Download to a stable partial file keyed by version, kept in binDir so an
+	// interrupted transfer (slow link, process restart) resumes instead of
+	// restarting at zero. Keying by version stops a resume from appending onto
+	// a stale partial left by a different version.
+	partialPath := filepath.Join(binDir, "greptime-"+resolvedVersion+".tar.gz.partial")
 
-	if err := downloadFile(tmpFile, downloadURL); err != nil {
+	if err := downloadFileResumable(partialPath, downloadURL, logger); err != nil {
+		// Keep the partial on the disk: the next attempt resumes from it.
 		if binExists {
 			logger.Warn("cannot download greptimedb, using existing binary",
 				"path", binPath, "error", err)
@@ -105,7 +113,16 @@ func EnsureGreptimeDB(dataDir, version string, logger *slog.Logger) (binPath str
 		return "", fmt.Errorf("install: download %s: %w", downloadURL, err)
 	}
 
+	tmpFile, err := os.Open(partialPath)
+	if err != nil {
+		return "", fmt.Errorf("install: reopen download: %w", err)
+	}
+	defer tmpFile.Close()
+
 	if err := verifyChecksum(tmpFile, resolvedVersion, logger); err != nil {
+		// A complete-looking but corrupt file must not be resumed onto; drop it
+		// so the next attempt re-downloads cleanly rather than looping forever.
+		_ = os.Remove(partialPath)
 		return "", fmt.Errorf("install: %w", err)
 	}
 
@@ -117,6 +134,7 @@ func EnsureGreptimeDB(dataDir, version string, logger *slog.Logger) (binPath str
 		return "", fmt.Errorf("install: extract binary: %w", err)
 	}
 
+	_ = os.Remove(partialPath) // extracted — reclaim the ~150 MB
 	_ = os.WriteFile(versionFile, []byte(resolvedVersion+"\n"), 0644)
 	logger.Info("greptimedb installed", "path", binPath, "version", resolvedVersion)
 	return binPath, nil
@@ -344,19 +362,58 @@ func buildDownloadURL(version, goos, goarch string) (string, error) {
 	return fmt.Sprintf("%s/download/%s/%s", githubReleaseBase, version, filename), nil
 }
 
-func downloadFile(dst io.Writer, url string) error {
-	resp, err := downloadClient.Get(url) //nolint:gosec // URL is constructed internally
+// downloadFileResumable downloads url to path, resuming from a partial file if
+// one already exists. It issues a Range request for the bytes it is still
+// missing; the server's response decides what happens:
+//
+//   - 206 Partial Content — the body is appended to the existing partial file.
+//   - 200 OK — the server ignored the Range header (or there was nothing to
+//     resume), so the file is truncated and rewritten from the start.
+//   - 416 Range Not Satisfiable — the partial already covers the whole asset;
+//     nothing to do. Any corruption is caught later by the checksum.
+//
+// On any read error the partial file is left in place so the next call resumes.
+func downloadFileResumable(path, url string, logger *slog.Logger) error {
+	var have int64
+	if fi, err := os.Stat(path); err == nil {
+		have = fi.Size()
+	}
+
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return err
+	}
+	if have > 0 {
+		req.Header.Set("Range", fmt.Sprintf("bytes=%d-", have))
+		logger.Info("resuming greptimedb download", "have_bytes", have)
+	}
+
+	resp, err := downloadClient.Do(req) //nolint:gosec // URL is constructed internally
 	if err != nil {
 		return err
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
+	var f *os.File
+	switch resp.StatusCode {
+	case http.StatusPartialContent:
+		f, err = os.OpenFile(path, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0644)
+	case http.StatusOK:
+		f, err = os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	case http.StatusRequestedRangeNotSatisfiable:
+		return nil
+	default:
 		return fmt.Errorf("HTTP %d fetching %s", resp.StatusCode, url)
 	}
+	if err != nil {
+		return err
+	}
+	defer f.Close()
 
-	_, err = io.Copy(dst, resp.Body)
-	return err
+	if _, err := io.Copy(f, resp.Body); err != nil {
+		return err // partial preserved — the next attempt resumes from here
+	}
+	return f.Sync()
 }
 
 // verifyChecksum downloads the sha256sum file for the given version and verifies


### PR DESCRIPTION
## Problem

Fixes #57. On a fresh install, `tma1-server` can get stuck in an infinite GreptimeDB download → 5‑minute‑timeout → retry loop on slower connections, never reaching a healthy state.

The download client (`server/internal/install/install.go`) had a **5‑minute `Client.Timeout`** that covers the whole request, including the `io.Copy` of the response body. The GreptimeDB tarball is **~150 MB**, so on any link slower than 150 MB / 5 min the body read is guillotined mid‑stream with `context deadline exceeded`, the partial download is discarded, and the install retries from zero — looping forever.

## Fix

1. **Drop the wall‑clock `Client.Timeout`** on the download client. Bound the connect/header phase with `Transport.ResponseHeaderTimeout` (60s) instead, so a dead endpoint still fails fast but a slow‑but‑progressing transfer is not killed.
2. **Resumable download.** Download to a stable per‑version partial file in `binDir` and resume via an HTTP `Range` request:
   - `206 Partial Content` → append to the partial.
   - `200 OK` (server ignored Range) → truncate and restart from scratch.
   - `416 Range Not Satisfiable` → partial already complete, no‑op.

   An interrupted transfer now continues instead of restarting, so each attempt makes forward progress and converges even under the old timeout.
3. **Self‑healing on corruption.** Delete the partial on checksum mismatch (so a corrupt file can't be resumed onto forever) and after successful extraction (to reclaim the ~150 MB).

## Tests

`download_resumable_test.go` covers, with an `httptest` server:
- fresh download (`200`),
- mid‑stream interruption + resume (`Range` → `206`),
- server that ignores `Range` (stale partial discarded via `200`+truncate),
- already‑complete partial (`416` no‑op).

`go test ./internal/install/ -race` and `go vet` pass; full `go build ./...` clean.

## Risk

Localized to the startup install path (`EnsureGreptimeDB` / download client). No signature changes to exported APIs, no schema changes. Impact analysis: only caller is `main` (startup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
