### PR TITLE
fix(hooks/codex): omit matcher key on UserPromptSubmit/Stop entries

### DIFF
--- a/server/internal/hooks/install_cc.go
+++ b/server/internal/hooks/install_cc.go
@@ -278,7 +278,7 @@ func (i *ClaudeCodeInstaller) installSettings(scriptPath string) (string, bool, 
 	}
 
 	command := wrapHookCommand(scriptPath)
-	if !registerTMA1HookEntries(existing, claudeCodeHookEvents, command) {
+	if !registerTMA1HookEntries(existing, claudeCodeHookEvents, command, nil) {
 		return settingsPath, false, nil
 	}
 

--- a/server/internal/hooks/install_cc_test.go
+++ b/server/internal/hooks/install_cc_test.go
@@ -163,10 +163,10 @@ func TestRegisterTMA1HooksReplacesOnCommandChange(t *testing.T) {
 			},
 		},
 	}
-	if !registerTMA1HookEntries(settings, claudeCodeHookEvents, "/new/path/tma1-hook.sh") {
+	if !registerTMA1HookEntries(settings, claudeCodeHookEvents, "/new/path/tma1-hook.sh", nil) {
 		t.Fatal("expected mutation when command changes")
 	}
-	if registerTMA1HookEntries(settings, claudeCodeHookEvents, "/new/path/tma1-hook.sh") {
+	if registerTMA1HookEntries(settings, claudeCodeHookEvents, "/new/path/tma1-hook.sh", nil) {
 		t.Error("expected no-op on second call with same command")
 	}
 }
@@ -492,7 +492,7 @@ func TestRegisterTMA1HooksCoversAllNativeEvents(t *testing.T) {
 	// missing, which silently broke perception rules that depend on
 	// those events for new users. Lock the full set.
 	settings := map[string]any{}
-	registerTMA1HookEntries(settings, claudeCodeHookEvents, "/path/to/tma1-hook.sh")
+	registerTMA1HookEntries(settings, claudeCodeHookEvents, "/path/to/tma1-hook.sh", nil)
 
 	hooks, _ := settings["hooks"].(map[string]any)
 	if hooks == nil {
@@ -573,7 +573,7 @@ func TestRegisterTMA1HooksAdoptsEquivalentLegacyEntry(t *testing.T) {
 			},
 		},
 	}
-	if !registerTMA1HookEntries(settings, claudeCodeHookEvents, resolved) {
+	if !registerTMA1HookEntries(settings, claudeCodeHookEvents, resolved, nil) {
 		t.Fatal("expected mutation when adopting legacy entry")
 	}
 	list := settings["hooks"].(map[string]any)["UserPromptSubmit"].([]any)

--- a/server/internal/hooks/install_codex.go
+++ b/server/internal/hooks/install_codex.go
@@ -87,6 +87,28 @@ var codexHookEvents = []string{
 	"Stop",
 }
 
+// codexMatcherlessEvents lists the Codex hook events that do not
+// support matchers. Codex itself drops the matcher for these events
+// before computing a hook's trust identity hash (codex-rs
+// hooks/src/events/common.rs, matcher_pattern_for_event:
+// `UserPromptSubmit | Stop => None`), so writing `"matcher": ""` on
+// them is not just redundant — it desyncs any tool that re-derives the
+// trust hash from the hooks.json definition verbatim. Concretely,
+// Stably Orca's managed CODEX_HOME re-hashes hook definitions
+// (including the empty matcher) and deletes runtime trust entries
+// whose hash doesn't match its expectation, trapping the user in an
+// endless "review hook / press t to trust" loop for exactly these two
+// events on every launch.
+//
+// Omitting the key entirely is safe on both axes: Codex treats an
+// absent matcher as match-all at dispatch time, and its own trust hash
+// for these events is unchanged (it already ignored the matcher), so
+// existing trusted installs are migrated without a re-trust prompt.
+var codexMatcherlessEvents = map[string]bool{
+	"UserPromptSubmit": true,
+	"Stop":             true,
+}
+
 func (i *CodexInstaller) writeFile(path string, data []byte, perm os.FileMode) error {
 	if i.DryRun {
 		if i.Logger != nil {
@@ -233,6 +255,9 @@ func (i *CodexInstaller) installSkill() ([]string, error) {
 //	  }
 //	}
 //
+// Events in codexMatcherlessEvents (UserPromptSubmit, Stop) are written
+// WITHOUT the "matcher" key — see that var for the trust-hash rationale.
+//
 // Idempotent: the `id: "tma1"` marker lets us find + rewrite our own
 // entry in place rather than appending duplicates. User-added entries
 // for the same event are preserved.
@@ -252,7 +277,7 @@ func (i *CodexInstaller) installHooksConfig(scriptPath string) (string, bool, er
 	}
 
 	command := wrapHookCommand(scriptPath)
-	if !registerTMA1HookEntries(existing, codexHookEvents, command) {
+	if !registerTMA1HookEntries(existing, codexHookEvents, command, codexMatcherlessEvents) {
 		return cfgPath, false, nil
 	}
 

--- a/server/internal/hooks/install_codex_test.go
+++ b/server/internal/hooks/install_codex_test.go
@@ -59,6 +59,18 @@ func TestCodexInstallEndToEndIdempotent(t *testing.T) {
 		if id, _ := first["id"].(string); id != "tma1" {
 			t.Errorf("%s entry missing id=tma1, got %v", event, first)
 		}
+		// Codex ignores matchers on UserPromptSubmit/Stop and drops
+		// them from the trust-identity hash, so the key must be absent
+		// there — a spurious `"matcher": ""` desyncs tools that
+		// re-derive the trust hash from the definition verbatim.
+		_, hasMatcher := first["matcher"]
+		if codexMatcherlessEvents[event] {
+			if hasMatcher {
+				t.Errorf("%s entry must not carry a matcher key, got %v", event, first)
+			}
+		} else if !hasMatcher {
+			t.Errorf("%s entry missing matcher key, got %v", event, first)
+		}
 	}
 
 	// config.toml's [mcp_servers.tma1] must carry the TMA1_MCP_CALLER
@@ -98,6 +110,86 @@ func TestCodexInstallEndToEndIdempotent(t *testing.T) {
 	}
 	if len(rep2.Changed) != 0 {
 		t.Errorf("second install should be a no-op, got changes: %v", rep2.Changed)
+	}
+}
+
+// TestCodexInstallMigratesEmptyMatcher seeds a hooks.json in the
+// legacy shape — `"matcher": ""` on every event, as written by older
+// TMA1 versions — and asserts one install pass strips the key from the
+// matcherless events (UserPromptSubmit/Stop), keeps it elsewhere, and
+// that a second pass is a no-op. Guards both directions of the
+// presence-aware entryEqual: it must fire once for the migration and
+// then never again.
+func TestCodexInstallMigratesEmptyMatcher(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	inst := &CodexInstaller{
+		DataDir: filepath.Join(home, ".tma1"),
+		Port:    14318,
+		Logger:  slog.Default(),
+	}
+	scriptPath := filepath.Join(home, ".tma1", "hooks", "tma1-hook-codex.sh")
+	command := wrapHookCommand(scriptPath)
+
+	legacy := map[string]any{"hooks": map[string]any{}}
+	for _, event := range codexHookEvents {
+		legacy["hooks"].(map[string]any)[event] = []any{
+			map[string]any{
+				"id":      "tma1",
+				"matcher": "",
+				"hooks": []any{
+					map[string]any{"type": "command", "command": command},
+				},
+			},
+		}
+	}
+	raw, err := json.Marshal(legacy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfgPath := filepath.Join(home, ".codex", "hooks.json")
+	if err := os.MkdirAll(filepath.Dir(cfgPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(cfgPath, raw, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, changed, err := inst.installHooksConfig(scriptPath)
+	if err != nil {
+		t.Fatalf("installHooksConfig: %v", err)
+	}
+	if !changed {
+		t.Fatal("migration pass should rewrite legacy empty-matcher entries")
+	}
+
+	var parsed map[string]any
+	if err := json.Unmarshal(mustRead(t, cfgPath), &parsed); err != nil {
+		t.Fatal(err)
+	}
+	hookSection, _ := parsed["hooks"].(map[string]any)
+	for _, event := range codexHookEvents {
+		entries, _ := hookSection[event].([]any)
+		if len(entries) != 1 {
+			t.Fatalf("%s: want 1 entry, got %v", event, entries)
+		}
+		entry, _ := entries[0].(map[string]any)
+		_, hasMatcher := entry["matcher"]
+		if codexMatcherlessEvents[event] && hasMatcher {
+			t.Errorf("%s: matcher key should be stripped, got %v", event, entry)
+		}
+		if !codexMatcherlessEvents[event] && !hasMatcher {
+			t.Errorf("%s: matcher key should be kept, got %v", event, entry)
+		}
+	}
+
+	_, changed, err = inst.installHooksConfig(scriptPath)
+	if err != nil {
+		t.Fatalf("second installHooksConfig: %v", err)
+	}
+	if changed {
+		t.Error("second pass should be a no-op after migration")
 	}
 }
 

--- a/server/internal/hooks/install_shared.go
+++ b/server/internal/hooks/install_shared.go
@@ -95,9 +95,9 @@ func entryEqual(a, b any) bool {
 		return false
 	}
 	if aok {
-		a1, _ := av.(string)
-		b1, _ := bv.(string)
-		if a1 != b1 {
+		a1, a1ok := av.(string)
+		b1, b1ok := bv.(string)
+		if !a1ok || !b1ok || a1 != b1 {
 			return false
 		}
 	}

--- a/server/internal/hooks/install_shared.go
+++ b/server/internal/hooks/install_shared.go
@@ -72,6 +72,14 @@ func entryCommand(entry map[string]any) string {
 // entryEqual reports whether two hook entries match on the fields TMA1
 // manages. User-extended fields are preserved by replacing entries
 // wholesale only when the command differs.
+//
+// The matcher comparison is presence-aware: `"matcher": ""` and no
+// matcher key at all are NOT equal. Codex hashes hook definitions into
+// trust identities, and for matcherless events an empty-string matcher
+// and an absent matcher can hash differently in tools that re-derive
+// that hash — so when the desired shape drops the key, an existing
+// entry that still carries it must be rewritten (one-time migration),
+// after which re-installs are no-ops again.
 func entryEqual(a, b any) bool {
 	am, _ := a.(map[string]any)
 	bm, _ := b.(map[string]any)
@@ -81,8 +89,17 @@ func entryEqual(a, b any) bool {
 	if id1, _ := am["id"].(string); id1 != bm["id"] {
 		return false
 	}
-	if m1, _ := am["matcher"].(string); m1 != bm["matcher"] {
+	av, aok := am["matcher"]
+	bv, bok := bm["matcher"]
+	if aok != bok {
 		return false
+	}
+	if aok {
+		a1, _ := av.(string)
+		b1, _ := bv.(string)
+		if a1 != b1 {
+			return false
+		}
 	}
 	return entryCommand(am) == entryCommand(bm)
 }
@@ -128,6 +145,12 @@ func matchesTMA1HookEntry(entry any, command, tmaID string) bool {
 // Codex's hooks.json, so this single helper backs both adapters; only
 // the event list differs.
 //
+// Events listed in `matcherlessEvents` get their entry written WITHOUT
+// a matcher key (nil means "none"). Agents that don't support matchers
+// on an event treat "" and absent identically at dispatch time, but the
+// raw definition can feed trust-hash computations (Codex), where the
+// spurious key changes the hash — see codexMatcherlessEvents.
+//
 // Two-pass matching avoids duplicate entries:
 //  1. Look for an entry whose hooks[].command resolves to the same script
 //     (after ~/ expansion). Catches old entries installed before we added
@@ -137,7 +160,7 @@ func matchesTMA1HookEntry(entry any, command, tmaID string) bool {
 // The matched entry is rewritten in place (canonical id + absolute
 // path). Other entries are left alone — that's important: user-added
 // hooks for the same event must keep working.
-func registerTMA1HookEntries(settings map[string]any, eventNames []string, command string) bool {
+func registerTMA1HookEntries(settings map[string]any, eventNames []string, command string, matcherlessEvents map[string]bool) bool {
 	hooks, _ := settings["hooks"].(map[string]any)
 	if hooks == nil {
 		hooks = map[string]any{}
@@ -149,14 +172,16 @@ func registerTMA1HookEntries(settings map[string]any, eventNames []string, comma
 		idx := findEquivalentEntry(list, command, hookOwnerID)
 
 		entry := map[string]any{
-			"matcher": "",
-			"id":      hookOwnerID,
+			"id": hookOwnerID,
 			"hooks": []any{
 				map[string]any{
 					"type":    "command",
 					"command": command,
 				},
 			},
+		}
+		if !matcherlessEvents[event] {
+			entry["matcher"] = ""
 		}
 
 		switch {


### PR DESCRIPTION
## Symptom

When Codex runs inside a wrapper that manages its own `CODEX_HOME` (e.g. [Stably Orca](https://github.com/stablyai/orca)'s `codex-runtime-home`), the TMA1 hook triggers an endless trust-review loop — **every** session shows:

```
Stop hooks
1 hook needs review before it can run.

[!] Hook 2 · new
Command  ~/.tma1/hooks/tma1-hook-codex.sh
Trust    New hook - review required
```

Pressing `t` trusts it for the current session, but the prompt is back on the next launch. Only `UserPromptSubmit` and `Stop` are affected; `SessionStart` / `PreToolUse` / `PostToolUse` stay trusted.

## Root cause

TMA1's installer writes `"matcher": ""` on every hook entry in `~/.codex/hooks.json`. But Codex doesn't support matchers on `UserPromptSubmit` and `Stop`, and **drops the matcher from those events' trust-identity hash** before comparing ([codex-rs `hooks/src/events/common.rs`](https://github.com/openai/codex/blob/main/codex-rs/hooks/src/events/common.rs)):

```rust
pub(crate) fn matcher_pattern_for_event(...) -> Option<&str> {
    match event_name {
        HookEventName::PreToolUse | ... | HookEventName::SessionStart => matcher,
        HookEventName::UserPromptSubmit | HookEventName::Stop => None,
    }
}
```

So for these two events, Codex's stored `trusted_hash` is computed **without** the matcher, while the hooks.json definition still carries the empty matcher. Any tool that re-derives the trust hash from the definition verbatim gets a different hash. Orca does exactly that when mirroring user hooks into its managed `CODEX_HOME`: its `computeTrustedHash` includes the empty matcher for all events, concludes the trust entry Codex wrote is stale, and deletes it on every launch (`removeStaleRuntimeHookTrustEntries`) → re-prompt forever. (I'm filing the complementary fix against Orca as well, but writing a matcher on an event that can't have one is wrong at the source regardless.)

Verified by recomputing both hash variants and matching them byte-for-byte against a real `~/.codex/config.toml`: the trusted hashes for `user_prompt_submit`/`stop` only match the matcher-omitted identity, the other three events only match the matcher-included identity.

## Fix

- `registerTMA1HookEntries` gains a `matcherlessEvents` set; entries for those events are written **without** the `matcher` key. Claude Code path passes `nil` (unchanged output).
- `codexMatcherlessEvents = {UserPromptSubmit, Stop}`, with a comment citing the Codex source.
- `entryEqual` is now presence-aware about `matcher` (`""` ≠ absent), so existing installs are migrated exactly once on the next install run and re-installs stay no-ops.

This is safe for existing users: Codex treats an absent matcher as match-all at dispatch time, and its own trust hash for these two events is unchanged (it already ignored the matcher), so the migration does **not** trigger a re-trust prompt in plain Codex.

## Testing

- `go test ./...` in `server/` — all green.
- `TestCodexInstallEndToEndIdempotent` extended: asserts the matcher key is absent on `UserPromptSubmit`/`Stop` and present on the other events.
- New `TestCodexInstallMigratesEmptyMatcher`: seeds a legacy hooks.json (`"matcher": ""` everywhere), asserts one pass strips the key from the two matcherless events and keeps it elsewhere, and that the second pass is a no-op.
- Manually verified on a live setup: after removing the empty matcher from the two entries, Codex-under-Orca stopped re-prompting (system-level Codex trust unaffected, no re-prompt there either).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
