### PR TITLE
chore(install): bump minimum GreptimeDB to v1.1.2

### DIFF
--- a/server/internal/install/install.go
+++ b/server/internal/install/install.go
@@ -29,7 +29,7 @@ const (
 	// even if the user configured "latest" (which normally skips network checks).
 	// Bump this when a new GreptimeDB release contains important fixes or
 	// breaking changes that tma1 depends on.
-	minRequiredVersion = "v1.0.2"
+	minRequiredVersion = "v1.1.2"
 )
 
 // greptimeBinaryName returns the platform-appropriate binary name.

--- a/server/internal/install/install_test.go
+++ b/server/internal/install/install_test.go
@@ -221,6 +221,9 @@ func TestVersionLessThan(t *testing.T) {
 		{"v1.0.0", "v1.0.2", true},      // pins the v1.0.2 minRequiredVersion floor
 		{"v1.0.1", "v1.0.2", true},
 		{"v1.0.2", "v1.0.2", false},
+		{"v1.0.2", "v1.1.2", true},      // pins the v1.1.2 minRequiredVersion floor
+		{"v1.1.1", "v1.1.2", true},
+		{"v1.1.2", "v1.1.2", false},
 		{"v2.0.0", "v1.0.0", false},
 		{"v0.12.0", "v0.12.1", true},
 		{"v1.0.0-alpha", "v1.0.0", true},  // pre-release < release

--- a/site/public/install.sh
+++ b/site/public/install.sh
@@ -128,7 +128,7 @@ download() {
 # --- Download GreptimeDB binary via official install script ---
 # Minimum GreptimeDB version required by TMA1. Keep in sync with
 # minRequiredVersion in server/internal/install/install.go.
-MIN_GREPTIMEDB_VERSION="1.0.2"
+MIN_GREPTIMEDB_VERSION="1.1.2"
 
 # version_lt returns 0 (true) if $1 < $2.
 # Compares major.minor.patch numerically; when equal, a pre-release


### PR DESCRIPTION
## What

Bump the minimum required GreptimeDB from **v1.0.2** to **v1.1.2**.

- `minRequiredVersion` in `server/internal/install/install.go`
- `MIN_GREPTIMEDB_VERSION` in `site/public/install.sh` (kept in sync per the in-file comment)
- Three comparator test cases in `install_test.go` pinning the new floor

## Why it's safe

Default config is `TMA1_GREPTIMEDB_VERSION=latest`. On the "latest" path, `checkVersionMismatch` re-resolves and upgrades whenever the installed version is below `minRequiredVersion` — so existing installs below v1.1.2 auto-upgrade on the next `tma1-server` start. New boxes get it via the curl-pipe installer, which also gates on `MIN_GREPTIMEDB_VERSION`. Users who pinned an explicit older version are unaffected (explicit tag wins).

The v1.1.2 release exists with all platform assets (darwin/linux/windows × arm64/amd64) plus `.sha256sum`, so both the runtime download + checksum verify and the install.sh path resolve cleanly.

## Testing

- `go test ./internal/install/ -run TestVersionLessThan` — green (new cases `v1.0.2 < v1.1.2`, `v1.1.1 < v1.1.2`, `v1.1.2 == v1.1.2`).
- `shellcheck site/public/install.sh` — clean.