### PR TITLE
fix(install): use Standard ProcessType for launchd agent

### DIFF
--- a/site/public/install.sh
+++ b/site/public/install.sh
@@ -279,7 +279,7 @@ setup_launchd() {
   <string>${log_path}</string>
 
   <key>ProcessType</key>
-  <string>Background</string>
+  <string>Standard</string>
 
   <key>SoftResourceLimits</key>
   <dict>


### PR DESCRIPTION
## Summary

The launchd plist generated by `install.sh` sets `ProcessType` to `Background`. On macOS this applies background QoS to `tma1-server` and every child it spawns — including the embedded GreptimeDB — and on Apple Silicon background-QoS processes are confined to efficiency cores.

When the machine is under load (E-cores saturated by other work), GreptimeDB gets almost no CPU time even while performance cores sit idle. Observed symptoms on an M-series Mac with high system load:

- `/api/query` latency of 10–30s, then 502s once the 30s internal timeout hits
- After a service restart, GreptimeDB cannot pass the 30s startup health check (the process sat in runnable state but accrued ~0.3s CPU over 12s), so the server loops start → health-check timeout → kill indefinitely and never comes back up
- `tma1-server` itself eventually exiting with code 1

Changing `ProcessType` to `Standard` removes the background scheduling clamp while keeping the agent fully launchd-managed (`RunAtLoad`, `KeepAlive` unchanged). Given tma1 sits on the interactive path of agent sessions (per-turn context injection blocks on it), background QoS is a poor fit.

## Testing

- Applied the same one-line change to a live install's plist (`plutil -replace ProcessType -string Standard`, then `launchctl bootout` + `bootstrap`): GreptimeDB passed its health check immediately, `/status` went from 0.5–3s to ~30ms and `/api/query` from 10–30s to ~5ms on the same loaded machine.
- `bash -n site/public/install.sh` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)