### PR TITLE
chore(install): bump minimum GreptimeDB to v1.1.3

### DIFF
--- a/server/internal/install/install.go
+++ b/server/internal/install/install.go
@@ -29,7 +29,7 @@ const (
 	// even if the user configured "latest" (which normally skips network checks).
 	// Bump this when a new GreptimeDB release contains important fixes or
 	// breaking changes that tma1 depends on.
-	minRequiredVersion = "v1.1.2"
+	minRequiredVersion = "v1.1.3"
 )
 
 // greptimeBinaryName returns the platform-appropriate binary name.

--- a/server/internal/install/install_test.go
+++ b/server/internal/install/install_test.go
@@ -224,6 +224,9 @@ func TestVersionLessThan(t *testing.T) {
 		{"v1.0.2", "v1.1.2", true},      // pins the v1.1.2 minRequiredVersion floor
 		{"v1.1.1", "v1.1.2", true},
 		{"v1.1.2", "v1.1.2", false},
+		{"v1.1.0", "v1.1.3", true},      // pins the v1.1.3 minRequiredVersion floor
+		{"v1.1.2", "v1.1.3", true},
+		{"v1.1.3", "v1.1.3", false},
 		{"v2.0.0", "v1.0.0", false},
 		{"v0.12.0", "v0.12.1", true},
 		{"v1.0.0-alpha", "v1.0.0", true},  // pre-release < release

--- a/site/public/install.sh
+++ b/site/public/install.sh
@@ -128,7 +128,7 @@ download() {
 # --- Download GreptimeDB binary via official install script ---
 # Minimum GreptimeDB version required by TMA1. Keep in sync with
 # minRequiredVersion in server/internal/install/install.go.
-MIN_GREPTIMEDB_VERSION="1.1.2"
+MIN_GREPTIMEDB_VERSION="1.1.3"
 
 # version_lt returns 0 (true) if $1 < $2.
 # Compares major.minor.patch numerically; when equal, a pre-release


### PR DESCRIPTION
Bumps the minimum required GreptimeDB from v1.1.2 to v1.1.3.

- `minRequiredVersion` in `server/internal/install/install.go`
- `MIN_GREPTIMEDB_VERSION` in `site/public/install.sh` (kept in sync)
- Three comparator test cases pinning the v1.1.3 floor

Existing installs below v1.1.3 auto-upgrade on next `tma1-server` start (the "latest" config path re-resolves when installed < minimum), or on next curl-pipe re-install for new boxes.