### PR TITLE
fix(install): probe binary for GreptimeDB version instead of a cached .version ledger

### DIFF
--- a/server/internal/install/install.go
+++ b/server/internal/install/install.go
@@ -56,18 +56,17 @@ func EnsureGreptimeDB(dataDir, version string, logger *slog.Logger) (binPath str
 	}
 
 	binPath = filepath.Join(binDir, greptimeBinaryName())
-	versionFile := filepath.Join(binDir, ".version")
 
 	binExists := false
 	if _, err := os.Stat(binPath); err == nil {
 		binExists = true
-		needsUpgrade, resolvedVer := checkVersionMismatch(version, versionFile, binPath, logger)
+		needsUpgrade, resolvedVer, installed := checkVersionMismatch(version, binPath, logger)
 		if !needsUpgrade {
 			logger.Info("greptimedb binary already present", "path", binPath, "version", resolvedVer)
 			return binPath, nil
 		}
 		logger.Info("greptimedb version mismatch, upgrading",
-			"installed", readVersionFile(versionFile), "requested", resolvedVer)
+			"installed", installed, "requested", resolvedVer)
 	}
 
 	resolvedVersion, err := resolveVersion(version)
@@ -117,47 +116,41 @@ func EnsureGreptimeDB(dataDir, version string, logger *slog.Logger) (binPath str
 		return "", fmt.Errorf("install: extract binary: %w", err)
 	}
 
-	_ = os.WriteFile(versionFile, []byte(resolvedVersion+"\n"), 0644)
 	logger.Info("greptimedb installed", "path", binPath, "version", resolvedVersion)
 	return binPath, nil
 }
 
-// checkVersionMismatch returns true if the installed version doesn't match the
-// requested version and an upgrade is needed. binPath is used to probe the
-// binary's version when the .version file is missing (legacy installs).
-func checkVersionMismatch(requestedVersion, versionFile, binPath string, logger *slog.Logger) (needsUpgrade bool, resolvedVer string) {
-	installed := readVersionFile(versionFile)
-	if installed == "" {
-		// Legacy install without .version file — probe the binary directly.
-		installed = probeBinaryVersion(binPath, logger)
-	}
+// checkVersionMismatch reports whether the installed binary needs an upgrade.
+// The binary itself is the source of truth: its --version output is probed
+// directly. There is no cached .version ledger — a cache buys a negligible
+// startup saving but drifts whenever the binary is upgraded out-of-band (the
+// install.sh / official installer path never wrote it), which silently forces
+// perpetual re-downloads on every start. installed is the probed version
+// (empty when the binary can't be probed) and is returned for logging.
+func checkVersionMismatch(requestedVersion, binPath string, logger *slog.Logger) (needsUpgrade bool, resolvedVer, installed string) {
+	installed = probeBinaryVersion(binPath, logger)
 
 	if requestedVersion == "latest" {
-		// If the installed version can't be determined, upgrade to be safe.
+		// Probe failed (binary missing/corrupt, or a non-semver nightly build)
+		// — upgrade to a resolvable release to be safe.
 		if installed == "" {
 			logger.Info("installed greptimedb version unknown, upgrading to latest")
-			return true, "latest"
-		}
-		// If the installed version can't be parsed, fall back to re-resolving.
-		if _, _, _, _, ok := parseSemver(installed); !ok {
-			logger.Info("installed greptimedb version unparseable, upgrading to latest",
-				"installed", installed)
-			return true, "latest"
+			return true, "latest", installed
 		}
 		// Check if the installed version is below the minimum required.
 		if versionLessThan(installed, minRequiredVersion) {
 			logger.Info("installed greptimedb is below minimum required version",
 				"installed", installed, "minimum", minRequiredVersion)
-			return true, "latest"
+			return true, "latest", installed
 		}
-		return false, installed
+		return false, installed, installed
 	}
 
 	if installed == "" {
 		// Can't determine version, re-download the requested one.
-		return true, requestedVersion
+		return true, requestedVersion, installed
 	}
-	return requestedVersion != installed, requestedVersion
+	return requestedVersion != installed, requestedVersion, installed
 }
 
 // probeBinaryVersion runs "greptime --version" and extracts the version tag.
@@ -193,14 +186,6 @@ func probeBinaryVersion(binPath string, logger *slog.Logger) string {
 	}
 	logger.Info("could not parse greptimedb version output", "output", string(out))
 	return ""
-}
-
-func readVersionFile(path string) string {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return ""
-	}
-	return strings.TrimSpace(string(data))
 }
 
 // versionLessThan compares two semver strings (e.g., "v1.0.0", "v0.12.0").

--- a/server/internal/install/install_test.go
+++ b/server/internal/install/install_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -67,91 +68,58 @@ func TestProbeBinaryVersion(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// readVersionFile
-// ---------------------------------------------------------------------------
-
-func TestReadVersionFile(t *testing.T) {
-	t.Run("normal", func(t *testing.T) {
-		f := filepath.Join(t.TempDir(), ".version")
-		if err := os.WriteFile(f, []byte("v0.12.0\n"), 0644); err != nil {
-			t.Fatal(err)
-		}
-		if got := readVersionFile(f); got != "v0.12.0" {
-			t.Errorf("got %q, want %q", got, "v0.12.0")
-		}
-	})
-
-	t.Run("file_not_found", func(t *testing.T) {
-		if got := readVersionFile("/no/such/file"); got != "" {
-			t.Errorf("got %q, want empty", got)
-		}
-	})
-
-	t.Run("empty_file", func(t *testing.T) {
-		f := filepath.Join(t.TempDir(), ".version")
-		if err := os.WriteFile(f, []byte(""), 0644); err != nil {
-			t.Fatal(err)
-		}
-		if got := readVersionFile(f); got != "" {
-			t.Errorf("got %q, want empty", got)
-		}
-	})
-
-	t.Run("trailing_whitespace", func(t *testing.T) {
-		f := filepath.Join(t.TempDir(), ".version")
-		if err := os.WriteFile(f, []byte("  v0.13.0 \n\n"), 0644); err != nil {
-			t.Fatal(err)
-		}
-		if got := readVersionFile(f); got != "v0.13.0" {
-			t.Errorf("got %q, want %q", got, "v0.13.0")
-		}
-	})
-}
-
-// ---------------------------------------------------------------------------
 // checkVersionMismatch
 // ---------------------------------------------------------------------------
 
 func TestCheckVersionMismatch(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell script trick not available on Windows")
+	}
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 
-	writeVersion := func(t *testing.T, content string) string {
+	// fakeBin writes a stub that prints the greptime --version format for a
+	// bare semver (e.g. "1.1.3"), so probeBinaryVersion resolves it to "v1.1.3".
+	fakeBin := func(t *testing.T, ver string) string {
 		t.Helper()
-		f := filepath.Join(t.TempDir(), ".version")
-		if err := os.WriteFile(f, []byte(content), 0644); err != nil {
+		f := filepath.Join(t.TempDir(), "greptime")
+		content := "#!/bin/sh\ncat <<'EOF'\ngreptime\nversion: " + ver + "\nEOF\n"
+		if err := os.WriteFile(f, []byte(content), 0755); err != nil {
 			t.Fatal(err)
 		}
 		return f
 	}
 
-	// binPath is unused when .version file exists; pass a non-existent path.
-	noBin := "/no/such/binary"
+	// minRequiredVersion without the leading "v", to build an at-minimum binary.
+	minBare := strings.TrimPrefix(minRequiredVersion, "v")
 
 	t.Run("latest_with_current_version_skips_upgrade", func(t *testing.T) {
-		vf := writeVersion(t, minRequiredVersion+"\n")
-		needs, resolved := checkVersionMismatch("latest", vf, noBin, logger)
+		needs, resolved, installed := checkVersionMismatch("latest", fakeBin(t, minBare), logger)
 		if needs {
 			t.Error("expected no upgrade needed")
 		}
 		if resolved != minRequiredVersion {
 			t.Errorf("resolved = %q, want %q", resolved, minRequiredVersion)
 		}
+		if installed != minRequiredVersion {
+			t.Errorf("installed = %q, want %q", installed, minRequiredVersion)
+		}
 	})
 
 	t.Run("latest_with_old_version_triggers_upgrade", func(t *testing.T) {
-		vf := writeVersion(t, "v0.12.0\n")
-		needs, resolved := checkVersionMismatch("latest", vf, noBin, logger)
+		needs, resolved, installed := checkVersionMismatch("latest", fakeBin(t, "0.12.0"), logger)
 		if !needs {
 			t.Error("expected upgrade needed for version below minimum")
 		}
 		if resolved != "latest" {
 			t.Errorf("resolved = %q, want %q", resolved, "latest")
 		}
+		if installed != "v0.12.0" {
+			t.Errorf("installed = %q, want %q", installed, "v0.12.0")
+		}
 	})
 
 	t.Run("exact_match_no_upgrade", func(t *testing.T) {
-		vf := writeVersion(t, "v0.12.0\n")
-		needs, resolved := checkVersionMismatch("v0.12.0", vf, noBin, logger)
+		needs, resolved, _ := checkVersionMismatch("v0.12.0", fakeBin(t, "0.12.0"), logger)
 		if needs {
 			t.Error("expected no upgrade needed")
 		}
@@ -161,8 +129,7 @@ func TestCheckVersionMismatch(t *testing.T) {
 	})
 
 	t.Run("mismatch_needs_upgrade", func(t *testing.T) {
-		vf := writeVersion(t, "v0.11.0\n")
-		needs, resolved := checkVersionMismatch("v0.12.0", vf, noBin, logger)
+		needs, resolved, _ := checkVersionMismatch("v0.12.0", fakeBin(t, "0.11.0"), logger)
 		if !needs {
 			t.Error("expected upgrade needed")
 		}
@@ -171,33 +138,32 @@ func TestCheckVersionMismatch(t *testing.T) {
 		}
 	})
 
-	t.Run("latest_with_unparseable_version_triggers_upgrade", func(t *testing.T) {
-		vf := writeVersion(t, "nightly-20260401\n")
-		needs, resolved := checkVersionMismatch("latest", vf, noBin, logger)
+	t.Run("latest_with_nonsemver_build_triggers_upgrade", func(t *testing.T) {
+		// A nightly / non-semver build can't be probed to a comparable version,
+		// so we upgrade to a resolvable release.
+		needs, resolved, _ := checkVersionMismatch("latest", fakeBin(t, "nightly-20260401"), logger)
 		if !needs {
-			t.Error("expected upgrade needed for unparseable version")
+			t.Error("expected upgrade needed for non-semver build")
 		}
 		if resolved != "latest" {
 			t.Errorf("resolved = %q, want %q", resolved, "latest")
 		}
 	})
 
-	t.Run("no_version_file_no_binary_triggers_upgrade_latest", func(t *testing.T) {
-		// Legacy install: no .version, binary can't be probed → upgrade.
-		needs, resolved := checkVersionMismatch("latest", "/no/such/file", noBin, logger)
+	t.Run("unprobeable_binary_triggers_upgrade_latest", func(t *testing.T) {
+		needs, resolved, _ := checkVersionMismatch("latest", "/no/such/binary", logger)
 		if !needs {
-			t.Error("expected upgrade for legacy install without .version")
+			t.Error("expected upgrade when the binary can't be probed")
 		}
 		if resolved != "latest" {
 			t.Errorf("resolved = %q, want %q", resolved, "latest")
 		}
 	})
 
-	t.Run("no_version_file_no_binary_triggers_upgrade_explicit", func(t *testing.T) {
-		// Explicit version requested, no .version, binary can't be probed → upgrade.
-		needs, resolved := checkVersionMismatch("v1.0.0", "/no/such/file", noBin, logger)
+	t.Run("unprobeable_binary_triggers_upgrade_explicit", func(t *testing.T) {
+		needs, resolved, _ := checkVersionMismatch("v1.0.0", "/no/such/binary", logger)
 		if !needs {
-			t.Error("expected upgrade for legacy install with explicit version")
+			t.Error("expected upgrade when the binary can't be probed")
 		}
 		if resolved != "v1.0.0" {
 			t.Errorf("resolved = %q, want %q", resolved, "v1.0.0")
@@ -218,30 +184,30 @@ func TestVersionLessThan(t *testing.T) {
 		{"v0.9.0", "v0.12.0", true},
 		{"v1.0.0", "v1.0.0", false},
 		{"v1.0.1", "v1.0.0", false},
-		{"v1.0.0", "v1.0.2", true},      // pins the v1.0.2 minRequiredVersion floor
+		{"v1.0.0", "v1.0.2", true}, // pins the v1.0.2 minRequiredVersion floor
 		{"v1.0.1", "v1.0.2", true},
 		{"v1.0.2", "v1.0.2", false},
-		{"v1.0.2", "v1.1.2", true},      // pins the v1.1.2 minRequiredVersion floor
+		{"v1.0.2", "v1.1.2", true}, // pins the v1.1.2 minRequiredVersion floor
 		{"v1.1.1", "v1.1.2", true},
 		{"v1.1.2", "v1.1.2", false},
-		{"v1.1.0", "v1.1.3", true},      // pins the v1.1.3 minRequiredVersion floor
+		{"v1.1.0", "v1.1.3", true}, // pins the v1.1.3 minRequiredVersion floor
 		{"v1.1.2", "v1.1.3", true},
 		{"v1.1.3", "v1.1.3", false},
 		{"v2.0.0", "v1.0.0", false},
 		{"v0.12.0", "v0.12.1", true},
-		{"v1.0.0-alpha", "v1.0.0", true},  // pre-release < release
+		{"v1.0.0-alpha", "v1.0.0", true}, // pre-release < release
 		{"v1.0.0-beta", "v1.0.0", true},
 		{"v1.0.0-rc1", "v1.0.0", true},
-		{"v1.0.0", "v1.0.0-rc1", false},   // release is NOT less than pre-release
-		{"v1.0.0-rc.1", "v1.0.0-rc.2", true},   // rc.1 < rc.2
+		{"v1.0.0", "v1.0.0-rc1", false},      // release is NOT less than pre-release
+		{"v1.0.0-rc.1", "v1.0.0-rc.2", true}, // rc.1 < rc.2
 		{"v1.0.0-rc.2", "v1.0.0-rc.1", false},
-		{"v1.0.0-rc.1", "v1.0.0-rc.1", false},  // equal
-		{"v1.0.0-alpha", "v1.0.0-beta", true},   // alpha < beta lexically
-		{"v1.0.0-beta", "v1.0.0-rc", true},      // beta < rc lexically
+		{"v1.0.0-rc.1", "v1.0.0-rc.1", false}, // equal
+		{"v1.0.0-alpha", "v1.0.0-beta", true}, // alpha < beta lexically
+		{"v1.0.0-beta", "v1.0.0-rc", true},    // beta < rc lexically
 		{"v1.0.0-alpha.1", "v1.0.0-alpha.2", true},
-		{"v1.0.0-rc", "v1.0.0-rc.1", true},      // shorter < longer when prefix matches
+		{"v1.0.0-rc", "v1.0.0-rc.1", true}, // shorter < longer when prefix matches
 		{"v0.9.0-rc1", "v1.0.0", true},
-		{"invalid", "v1.0.0", false},       // parse error → conservative false
+		{"invalid", "v1.0.0", false}, // parse error → conservative false
 		{"v1.0.0", "invalid", false},
 	}
 	for _, tt := range tests {
@@ -326,7 +292,7 @@ func TestExtractBinary(t *testing.T) {
 	t.Run("finds_greptime", func(t *testing.T) {
 		content := []byte("fake-binary-content")
 		archive := makeTarGz(t, map[string][]byte{
-			"some-dir/README.md":                    []byte("readme"),
+			"some-dir/README.md":               []byte("readme"),
 			"some-dir/" + greptimeBinaryName(): content,
 		})
 


### PR DESCRIPTION
## Problem

A server in a re-download loop: every ~2 min it logged `downloading greptimedb v1.1.3` but never `greptimedb installed`, while the on-disk binary was already v1.1.3.

Root cause is two sources of truth that drifted:

- `install.sh` (and the official installer it shells out to) download the binary and gate on the binary's real `greptime --version` — they **never write** `~/.tma1/bin/.version`.
- The Go server's `checkVersionMismatch` **trusted the `.version` ledger first**, only probing the binary when the file was absent.

So a ledger stuck at `v1.0.2` (while the binary was upgraded to v1.1.3 out-of-band) made every start decide it was below the `minRequiredVersion` floor and re-download.

## Fix

The binary's own `--version` is the only reliable source of truth — the ledger could only ever be equal-or-staler, for a negligible startup saving. Remove it:

- `checkVersionMismatch` probes the binary directly (drops the `versionFile` param) and returns the probed version for the upgrade log.
- Stop writing `.version` on download; remove `readVersionFile`.
- **Self-heals** installs whose ledger already drifted — next start probes v1.1.3, sees it meets the floor, and stops re-downloading.

Existing stale `.version` files become inert (nothing reads them).

## Testing

- `go test ./internal/install/` — rewrote the version-mismatch tests to stub a fake `greptime` binary instead of seeding a `.version` file.
- `go vet`, `gofmt`, `go build ./...` clean.