### PR TITLE
fix: bound watcher fd usage and stop full-table dashboard scans

### DIFF
--- a/server/cmd/tma1-server/main.go
+++ b/server/cmd/tma1-server/main.go
@@ -301,6 +301,25 @@ func runHelp(args []string, stdout, stderr io.Writer) int {
 	return 0
 }
 
+// logRotateThreshold is the size past which the redirected stdout log is
+// truncated at startup. High enough that a crash loop won't reach it in one
+// sitting (so the crash log survives), low enough to cap disk use.
+const logRotateThreshold = 128 << 20 // 128 MiB
+
+// rotateLogIfLarge truncates f in place when it is a regular file grown past
+// maxBytes. It targets the service manager's redirected stdout/stderr: both
+// are appended (O_APPEND) to one file, so a plain Truncate(0) resets it and
+// subsequent writes resume from the new EOF — no path lookup, and stderr
+// (same inode) is reclaimed too. When f is a tty or pipe (interactive run, or
+// journald on Linux) Stat reports a non-regular file and this is a no-op.
+func rotateLogIfLarge(f *os.File, maxBytes int64) {
+	fi, err := f.Stat()
+	if err != nil || !fi.Mode().IsRegular() || fi.Size() < maxBytes {
+		return
+	}
+	_ = f.Truncate(0)
+}
+
 func main() {
 	// Subcommand routing. The default (no args) runs the full HTTP server.
 	if len(os.Args) > 1 {
@@ -328,6 +347,12 @@ func main() {
 	default:
 		logLevel.Set(slog.LevelInfo)
 	}
+
+	// Reclaim the redirected stdout/stderr log before we start writing to it.
+	// Under launchd/systemd both streams append to one file that would grow
+	// without bound (every HTTP request is access-logged). No-op when stdout
+	// isn't a regular file (tty, or a journald pipe on Linux).
+	rotateLogIfLarge(os.Stdout, logRotateThreshold)
 
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
 		Level: &logLevel,

--- a/server/cmd/tma1-server/main_test.go
+++ b/server/cmd/tma1-server/main_test.go
@@ -2,9 +2,51 @@ package main
 
 import (
 	"bytes"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
+
+func TestRotateLogIfLarge(t *testing.T) {
+	newFile := func(size int) *os.File {
+		f, err := os.CreateTemp(t.TempDir(), "log")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := f.Write(make([]byte, size)); err != nil {
+			t.Fatal(err)
+		}
+		return f
+	}
+
+	t.Run("truncates when at or over threshold", func(t *testing.T) {
+		f := newFile(100)
+		defer f.Close()
+		rotateLogIfLarge(f, 50)
+		if fi, _ := f.Stat(); fi.Size() != 0 {
+			t.Errorf("size = %d, want 0", fi.Size())
+		}
+	})
+
+	t.Run("keeps when under threshold", func(t *testing.T) {
+		f := newFile(30)
+		defer f.Close()
+		rotateLogIfLarge(f, 50)
+		if fi, _ := f.Stat(); fi.Size() != 30 {
+			t.Errorf("size = %d, want 30", fi.Size())
+		}
+	})
+
+	t.Run("no-op on non-regular file", func(t *testing.T) {
+		d, err := os.Open(filepath.Dir(t.TempDir()))
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer d.Close()
+		rotateLogIfLarge(d, 0) // must not panic or truncate a directory
+	})
+}
 
 func TestDispatch(t *testing.T) {
 	tests := []struct {

--- a/server/internal/sensor/git/gitignore_test.go
+++ b/server/internal/sensor/git/gitignore_test.go
@@ -103,7 +103,7 @@ func TestMatchesWindowsPathsAgainstPOSIXPatterns(t *testing.T) {
 		path string
 		want bool
 	}{
-		{`C:\repo\bin\tma1-server.exe`, true},  // dir pattern
+		{`C:\repo\bin\tma1-server.exe`, true}, // dir pattern
 		{`C:\repo\node_modules\react\index.js`, true},
 		{`C:\repo\var\app.log`, true}, // suffix pattern
 		{`C:\repo\docs\secrets.md`, true},

--- a/server/internal/sensor/git/sensor.go
+++ b/server/internal/sensor/git/sensor.go
@@ -17,10 +17,10 @@ import (
 //
 // The sensor is closed by canceling the context passed to Start.
 type Sensor struct {
-	writer  EventWriter
-	attr    Attributor
-	logger  *slog.Logger
-	host    string
+	writer EventWriter
+	attr   Attributor
+	logger *slog.Logger
+	host   string
 
 	mu       sync.Mutex
 	watching map[string]*projectWatcher // project_root → watcher

--- a/server/internal/sensor/git/watcher.go
+++ b/server/internal/sensor/git/watcher.go
@@ -3,9 +3,11 @@ package git
 import (
 	"context"
 	"log/slog"
+	"math"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -26,8 +28,12 @@ const (
 
 	maxWatchDirs = 2048
 
-	// On macOS fsnotify uses kqueue, which opens one fd per file in every
-	// watched dir — so the fd budget that matters is files, not dirs.
+	// maxWatchFiles / maxWatchDirEntries only apply on kqueue (macOS), where
+	// fsnotify opens one fd per file in every watched dir — there the fd budget
+	// that matters is files, not dirs. On inotify (Linux) and Windows a watch
+	// is per-directory, so file counts don't track resource use; both limits
+	// are disabled there (see platformWatchLimits) to avoid dropping changes in
+	// large repos.
 	maxWatchFiles = 4096
 
 	// A dir with this many files is almost certainly an asset/content folder,
@@ -37,6 +43,28 @@ const (
 	// genuinely huge asset/generated folders (which run to thousands) get cut.
 	maxWatchDirEntries = 512
 )
+
+// watchLimits bounds a single project walk. dirs caps registered directories
+// (meaningful on every backend); files and dirEntries cap file-descriptor cost
+// and only bite on kqueue (see platformWatchLimits).
+type watchLimits struct {
+	dirs       int
+	files      int
+	dirEntries int
+}
+
+// platformWatchLimits returns the walk caps for the current OS. Only kqueue
+// charges a descriptor per watched file, so the file-count caps are disabled
+// off macOS — there a watch is per-directory and file counts would needlessly
+// truncate coverage of large repos.
+func platformWatchLimits() watchLimits {
+	l := watchLimits{dirs: maxWatchDirs, files: maxWatchFiles, dirEntries: maxWatchDirEntries}
+	if runtime.GOOS != "darwin" {
+		l.files = math.MaxInt
+		l.dirEntries = math.MaxInt
+	}
+	return l
+}
 
 // projectWatcher watches one project root. It blends fsnotify (file
 // modifications) with a periodic git poll (commit / branch movement).
@@ -90,14 +118,15 @@ func (w *projectWatcher) start() error {
 	// Best-effort recursive watch by walking once at start. Subdirectories
 	// created later don't auto-attach — for Phase 1.2 this is acceptable;
 	// most projects have stable directory layouts.
-	added, stopped, err := addRecursive(fsw, w.cfg.Root, maxWatchDirs, maxWatchFiles, w.dirShouldIgnore)
+	limits := platformWatchLimits()
+	added, stopped, err := addRecursive(fsw, w.cfg.Root, limits, w.dirShouldIgnore)
 	if err != nil {
 		_ = fsw.Close()
 		return err
 	}
 	if stopped {
 		w.logger.Warn("git watcher: stopped registering watches early (dir/file cap or fd limit); deeper subdirs unwatched",
-			"root", w.cfg.Root, "dir_cap", maxWatchDirs, "file_cap", maxWatchFiles, "watched_dirs", added)
+			"root", w.cfg.Root, "dir_cap", limits.dirs, "file_cap", limits.files, "watched_dirs", added)
 	}
 
 	w.wg.Add(2)
@@ -402,10 +431,16 @@ func (w *projectWatcher) dirShouldIgnore(dir string) bool {
 // dir cap, the file cap, or the first fsnotify.Add failure. Walk errors are
 // non-fatal (partial coverage beats none).
 //
+// The root directory itself is never subject to the ignore predicate: it is
+// the thing we were asked to watch, and a project whose .gitignore lists an
+// artifact sharing the repo's own name (e.g. `/codora` in a repo named codora)
+// would otherwise prune the root and start with zero watches, silently missing
+// every change.
+//
 // Stopping on the first Add failure matters: once Add returns EMFILE/ENOSPC the
 // fd table is full, so every further Add fails too — continuing just burns IO
 // on a doomed walk.
-func addRecursive(fsw *fsnotify.Watcher, root string, dirLimit, fileLimit int, ignore func(dir string) bool) (int, bool, error) {
+func addRecursive(fsw *fsnotify.Watcher, root string, limits watchLimits, ignore func(dir string) bool) (int, bool, error) {
 	dirs := 0
 	files := 0
 	stopped := false
@@ -416,16 +451,16 @@ func addRecursive(fsw *fsnotify.Watcher, root string, dirLimit, fileLimit int, i
 		if !info.IsDir() {
 			return nil
 		}
-		if ignore(path) {
+		if path != root && ignore(path) {
 			return filepath.SkipDir
 		}
-		if dirs >= dirLimit || files >= fileLimit {
+		if dirs >= limits.dirs || files >= limits.files {
 			stopped = true
 			return filepath.SkipAll
 		}
 
 		fileCount := countFiles(path)
-		if fileCount > maxWatchDirEntries {
+		if fileCount > limits.dirEntries {
 			return nil // skip the dir, but keep descending into its subdirs
 		}
 

--- a/server/internal/sensor/git/watcher.go
+++ b/server/internal/sensor/git/watcher.go
@@ -53,6 +53,13 @@ type watchLimits struct {
 	dirEntries int
 }
 
+// fileCapped reports whether the per-file caps are active. When both are
+// disabled (off kqueue) the walk can skip counting a directory's files
+// entirely — the count would only feed limits that never trip.
+func (l watchLimits) fileCapped() bool {
+	return l.files != math.MaxInt || l.dirEntries != math.MaxInt
+}
+
 // platformWatchLimits returns the walk caps for the current OS. Only kqueue
 // charges a descriptor per watched file, so the file-count caps are disabled
 // off macOS — there a watch is per-directory and file counts would needlessly
@@ -454,14 +461,23 @@ func addRecursive(fsw *fsnotify.Watcher, root string, limits watchLimits, ignore
 		if path != root && ignore(path) {
 			return filepath.SkipDir
 		}
-		if dirs >= limits.dirs || files >= limits.files {
+		if dirs >= limits.dirs {
 			stopped = true
 			return filepath.SkipAll
 		}
 
-		fileCount := countFiles(path)
-		if fileCount > limits.dirEntries {
-			return nil // skip the dir, but keep descending into its subdirs
+		// File/entry accounting only matters on kqueue, where each watched
+		// file costs an fd. Off it the countFiles scan is pure wasted IO.
+		fileCount := 0
+		if limits.fileCapped() {
+			fileCount = countFiles(path)
+			if fileCount > limits.dirEntries {
+				return nil // skip the asset dir, but keep descending its subdirs
+			}
+			if files+fileCount > limits.files {
+				stopped = true // Adding this dir would exceed the fd budget
+				return filepath.SkipAll
+			}
 		}
 
 		if fsw.Add(path) != nil {

--- a/server/internal/sensor/git/watcher.go
+++ b/server/internal/sensor/git/watcher.go
@@ -24,14 +24,18 @@ const (
 	// emit Create + Remove + Write within a few ms).
 	fsEventDebounce = 500 * time.Millisecond
 
-	// maxWatchDirs bounds how many directories one watcher tries to register
-	// with fsnotify. On macOS each watched dir costs file descriptors (kqueue
-	// opens the dir and its entries), so an unbounded walk over a giant
-	// monorepo — or a root that resolved too wide — can exhaust the process
-	// fd limit and wedge the HTTP listener with EMFILE. 2048 covers real
-	// projects with headroom; past it we stop adding and warn once rather
-	// than leak descriptors or keep walking after Add starts failing.
 	maxWatchDirs = 2048
+
+	// On macOS fsnotify uses kqueue, which opens one fd per file in every
+	// watched dir — so the fd budget that matters is files, not dirs.
+	maxWatchFiles = 4096
+
+	// A dir with this many files is almost certainly an asset/content folder,
+	// not hand-edited source; skip it rather than spend an fd per file. Well
+	// above a typical source dir (usually <100, occasionally a few hundred for
+	// large packages / codegen), so real code is never dropped — only the
+	// genuinely huge asset/generated folders (which run to thousands) get cut.
+	maxWatchDirEntries = 512
 )
 
 // projectWatcher watches one project root. It blends fsnotify (file
@@ -86,14 +90,14 @@ func (w *projectWatcher) start() error {
 	// Best-effort recursive watch by walking once at start. Subdirectories
 	// created later don't auto-attach — for Phase 1.2 this is acceptable;
 	// most projects have stable directory layouts.
-	added, stopped, err := addRecursive(fsw, w.cfg.Root, maxWatchDirs)
+	added, stopped, err := addRecursive(fsw, w.cfg.Root, maxWatchDirs, maxWatchFiles, w.dirShouldIgnore)
 	if err != nil {
 		_ = fsw.Close()
 		return err
 	}
 	if stopped {
-		w.logger.Warn("git watcher: stopped registering watches early (cap or fd limit); deeper subdirs unwatched",
-			"root", w.cfg.Root, "cap", maxWatchDirs, "watched", added)
+		w.logger.Warn("git watcher: stopped registering watches early (dir/file cap or fd limit); deeper subdirs unwatched",
+			"root", w.cfg.Root, "dir_cap", maxWatchDirs, "file_cap", maxWatchFiles, "watched_dirs", added)
 	}
 
 	w.wg.Add(2)
@@ -271,12 +275,24 @@ var staticIgnoreFragments = []string{
 	"/dist/",
 	"/build/",
 	"/target/",
-	"/bin/",    // Go build outputs (server/bin, tooling). Dropped here
-	"/out/",    // Java / generic build output dir
-	"/vendor/", // Go / PHP / Ruby vendored deps
-	"/.venv/",  // Python venv
-	"/venv/",   // Python venv (alt)
-	"/.tma1/",  // tma1's own data dir (avoids self-noise loop)
+	"/bin/",              // Go build outputs (server/bin, tooling). Dropped here
+	"/out/",              // Java / generic build output dir
+	"/vendor/",           // Go / PHP / Ruby vendored deps
+	"/.venv/",            // Python venv
+	"/venv/",             // Python venv (alt)
+	"/.gocache/",         // Go build cache (projects that set GOCACHE in-tree)
+	"/.gradle/",          // Gradle build state
+	"/.turbo/",           // Turborepo cache
+	"/.svelte-kit/",      // SvelteKit generated
+	"/.nuxt/",            // Nuxt generated
+	"/.parcel-cache/",    // Parcel cache
+	"/.angular/",         // Angular cache
+	"/.vitepress/cache/", // VitePress dev cache
+	"/.vitepress/dist/",  // VitePress build output
+	"/.mypy_cache/",      // mypy cache
+	"/.ruff_cache/",      // ruff cache
+	"/.terraform/",       // Terraform provider/plugin cache
+	"/.tma1/",            // tma1's own data dir (avoids self-noise loop)
 	"/.idea/",
 	"/.vscode/",
 	"/__pycache__/",
@@ -366,18 +382,32 @@ func (w *projectWatcher) shouldIgnorePath(p string) bool {
 	return false
 }
 
-// addRecursive walks root and registers up to limit directories with the
-// watcher, skipping ignored paths. It returns the number of directories
-// successfully added and whether the walk stopped early — either because it
-// hit limit or because fsnotify.Add began failing. Walk errors are non-fatal
-// (partial coverage beats none).
+// dirShouldIgnore prunes a directory at walk time. Unlike shouldIgnorePath,
+// which only drops a change record after the fact, pruning here stops the dir's
+// files from ever costing a descriptor — the whole point of honouring
+// .gitignore against build/cache dirs. The trailing slash is what the static
+// fragment list matches directories on.
+func (w *projectWatcher) dirShouldIgnore(dir string) bool {
+	if staticShouldIgnorePath(dir + "/") {
+		return true
+	}
+	if w.gitignore != nil && w.gitignore.matches(dir, w.cfg.Root) {
+		return true
+	}
+	return false
+}
+
+// addRecursive walks root and registers directories with the watcher. It
+// returns how many dirs were added and whether the walk stopped early — on the
+// dir cap, the file cap, or the first fsnotify.Add failure. Walk errors are
+// non-fatal (partial coverage beats none).
 //
-// Stopping on the first Add failure matters: once Add returns EMFILE/ENOSPC
-// the fd/watch table is full, so every further Add fails too. Continuing the
-// traversal would just burn time and IO on a doomed walk — exactly the cost
-// this watcher cap exists to avoid.
-func addRecursive(fsw *fsnotify.Watcher, root string, limit int) (int, bool, error) {
-	added := 0
+// Stopping on the first Add failure matters: once Add returns EMFILE/ENOSPC the
+// fd table is full, so every further Add fails too — continuing just burns IO
+// on a doomed walk.
+func addRecursive(fsw *fsnotify.Watcher, root string, dirLimit, fileLimit int, ignore func(dir string) bool) (int, bool, error) {
+	dirs := 0
+	files := 0
 	stopped := false
 	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
@@ -386,21 +416,42 @@ func addRecursive(fsw *fsnotify.Watcher, root string, limit int) (int, bool, err
 		if !info.IsDir() {
 			return nil
 		}
-		if staticShouldIgnorePath(path + "/") {
+		if ignore(path) {
 			return filepath.SkipDir
 		}
-		if added >= limit {
-			stopped = true // hit the watch cap
+		if dirs >= dirLimit || files >= fileLimit {
+			stopped = true
 			return filepath.SkipAll
 		}
+
+		fileCount := countFiles(path)
+		if fileCount > maxWatchDirEntries {
+			return nil // skip the dir, but keep descending into its subdirs
+		}
+
 		if fsw.Add(path) != nil {
-			stopped = true // Add failing (fd/watch exhaustion) — abandon the walk
+			stopped = true // fd/watch table full — every further Add fails too
 			return filepath.SkipAll
 		}
-		added++
+		dirs++
+		files += fileCount
 		return nil
 	})
-	return added, stopped, err
+	return dirs, stopped, err
+}
+
+func countFiles(dir string) int {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return 0
+	}
+	n := 0
+	for _, e := range entries {
+		if !e.IsDir() {
+			n++
+		}
+	}
+	return n
 }
 
 // readGitHead returns the SHA of HEAD or "" on failure. The context lets a

--- a/server/internal/sensor/git/watcher_test.go
+++ b/server/internal/sensor/git/watcher_test.go
@@ -1,13 +1,34 @@
 package git
 
 import (
+	"math"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"testing"
 
 	"github.com/fsnotify/fsnotify"
 )
+
+func TestPlatformWatchLimits(t *testing.T) {
+	l := platformWatchLimits()
+	if l.dirs != maxWatchDirs {
+		t.Errorf("dirs = %d, want %d on every platform", l.dirs, maxWatchDirs)
+	}
+	if runtime.GOOS == "darwin" {
+		// kqueue charges a descriptor per file — file caps stay active.
+		if l.files != maxWatchFiles || l.dirEntries != maxWatchDirEntries {
+			t.Errorf("darwin file caps = (%d,%d), want (%d,%d)",
+				l.files, l.dirEntries, maxWatchFiles, maxWatchDirEntries)
+		}
+	} else {
+		// inotify / Windows watch per directory — file caps must be disabled.
+		if l.files != math.MaxInt || l.dirEntries != math.MaxInt {
+			t.Errorf("non-darwin file caps = (%d,%d), want disabled (MaxInt)", l.files, l.dirEntries)
+		}
+	}
+}
 
 func TestStaticShouldIgnorePath(t *testing.T) {
 	cases := []struct {
@@ -76,7 +97,7 @@ func TestAddRecursiveRespectsCap(t *testing.T) {
 		}
 		defer fsw.Close()
 
-		added, stopped, err := addRecursive(fsw, root, 3, maxWatchFiles, noIgnore)
+		added, stopped, err := addRecursive(fsw, root, dirCap(3), noIgnore)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -95,7 +116,7 @@ func TestAddRecursiveRespectsCap(t *testing.T) {
 		}
 		defer fsw.Close()
 
-		added, stopped, err := addRecursive(fsw, root, 100, maxWatchFiles, noIgnore)
+		added, stopped, err := addRecursive(fsw, root, dirCap(100), noIgnore)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -116,7 +137,7 @@ func TestAddRecursiveRespectsCap(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		added, stopped, err := addRecursive(fsw, root, 3, maxWatchFiles, noIgnore)
+		added, stopped, err := addRecursive(fsw, root, dirCap(3), noIgnore)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -130,6 +151,16 @@ func TestAddRecursiveRespectsCap(t *testing.T) {
 }
 
 func noIgnore(string) bool { return false }
+
+func fullLimits() watchLimits {
+	return watchLimits{dirs: maxWatchDirs, files: maxWatchFiles, dirEntries: maxWatchDirEntries}
+}
+
+func dirCap(n int) watchLimits {
+	l := fullLimits()
+	l.dirs = n
+	return l
+}
 
 func TestAddRecursivePrunesAndBudgets(t *testing.T) {
 	root := t.TempDir()
@@ -157,7 +188,7 @@ func TestAddRecursivePrunesAndBudgets(t *testing.T) {
 		defer fsw.Close()
 
 		ignore := func(dir string) bool { return filepath.Base(dir) == "skipme" }
-		added, _, err := addRecursive(fsw, root, maxWatchDirs, maxWatchFiles, ignore)
+		added, _, err := addRecursive(fsw, root, fullLimits(), ignore)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -178,7 +209,7 @@ func TestAddRecursivePrunesAndBudgets(t *testing.T) {
 		}
 		defer fsw.Close()
 
-		added, _, err := addRecursive(fsw, filepath.Join(root, "assets"), maxWatchDirs, maxWatchFiles, noIgnore)
+		added, _, err := addRecursive(fsw, filepath.Join(root, "assets"), fullLimits(), noIgnore)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -200,7 +231,9 @@ func TestAddRecursivePrunesAndBudgets(t *testing.T) {
 		defer fsw.Close()
 
 		// fileLimit 5: root(0) + d0(3) + d1(3=6) trips the budget before d2.
-		added, stopped, err := addRecursive(fsw, froot, maxWatchDirs, 5, noIgnore)
+		limits := fullLimits()
+		limits.files = 5
+		added, stopped, err := addRecursive(fsw, froot, limits, noIgnore)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -209,6 +242,30 @@ func TestAddRecursivePrunesAndBudgets(t *testing.T) {
 		}
 		if added != 3 { // root + d0 + d1; d2 cut by the file budget
 			t.Errorf("added = %d, want 3 (root + d0 + d1 before budget)", added)
+		}
+	})
+
+	t.Run("root is never pruned by the ignore predicate", func(t *testing.T) {
+		proot := t.TempDir()
+		writeFiles(filepath.Join(proot, "src"), 1)
+
+		fsw, err := fsnotify.NewWatcher()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer fsw.Close()
+
+		// Mirrors a repo whose .gitignore lists an artifact sharing its own
+		// name, making the matcher hit the root. The root must still be
+		// watched — otherwise the walk registers zero watches and every
+		// change is silently missed.
+		ignoreAll := func(string) bool { return true }
+		added, _, err := addRecursive(fsw, proot, fullLimits(), ignoreAll)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if added < 1 {
+			t.Errorf("added = %d, want >=1 (root watched despite ignore match)", added)
 		}
 	})
 }

--- a/server/internal/sensor/git/watcher_test.go
+++ b/server/internal/sensor/git/watcher_test.go
@@ -230,7 +230,8 @@ func TestAddRecursivePrunesAndBudgets(t *testing.T) {
 		}
 		defer fsw.Close()
 
-		// fileLimit 5: root(0) + d0(3) + d1(3=6) trips the budget before d2.
+		// fileLimit 5: root(0) + d0(3) = 3 fits; d1 (3) would push to 6 > 5,
+		// so it's cut before Add — the budget is never exceeded.
 		limits := fullLimits()
 		limits.files = 5
 		added, stopped, err := addRecursive(fsw, froot, limits, noIgnore)
@@ -240,8 +241,33 @@ func TestAddRecursivePrunesAndBudgets(t *testing.T) {
 		if !stopped {
 			t.Fatal("stopped = false, want true (file budget hit)")
 		}
-		if added != 3 { // root + d0 + d1; d2 cut by the file budget
-			t.Errorf("added = %d, want 3 (root + d0 + d1 before budget)", added)
+		if added != 2 { // root + d0; d1 cut before Add to keep files <= 5
+			t.Errorf("added = %d, want 2 (root + d0; d1 would exceed budget)", added)
+		}
+	})
+
+	t.Run("disabled file caps watch asset-heavy dirs", func(t *testing.T) {
+		aroot := t.TempDir()
+		writeFiles(filepath.Join(aroot, "assets"), maxWatchDirEntries+1)
+
+		fsw, err := fsnotify.NewWatcher()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer fsw.Close()
+
+		// Off kqueue the file caps are MaxInt: a file-heavy dir must still be
+		// watched, and countFiles is skipped entirely.
+		uncapped := watchLimits{dirs: maxWatchDirs, files: math.MaxInt, dirEntries: math.MaxInt}
+		added, stopped, err := addRecursive(fsw, aroot, uncapped, noIgnore)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if stopped {
+			t.Fatal("stopped = true, want false (no file caps)")
+		}
+		if added != 2 { // root + assets; not skipped despite file count
+			t.Errorf("added = %d, want 2 (asset dir watched when caps disabled)", added)
 		}
 	})
 

--- a/server/internal/sensor/git/watcher_test.go
+++ b/server/internal/sensor/git/watcher_test.go
@@ -76,7 +76,7 @@ func TestAddRecursiveRespectsCap(t *testing.T) {
 		}
 		defer fsw.Close()
 
-		added, stopped, err := addRecursive(fsw, root, 3)
+		added, stopped, err := addRecursive(fsw, root, 3, maxWatchFiles, noIgnore)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -95,7 +95,7 @@ func TestAddRecursiveRespectsCap(t *testing.T) {
 		}
 		defer fsw.Close()
 
-		added, stopped, err := addRecursive(fsw, root, 100)
+		added, stopped, err := addRecursive(fsw, root, 100, maxWatchFiles, noIgnore)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -116,7 +116,7 @@ func TestAddRecursiveRespectsCap(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		added, stopped, err := addRecursive(fsw, root, 3)
+		added, stopped, err := addRecursive(fsw, root, 3, maxWatchFiles, noIgnore)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -125,6 +125,90 @@ func TestAddRecursiveRespectsCap(t *testing.T) {
 		}
 		if added != 0 {
 			t.Errorf("added = %d, want 0 after watcher is closed", added)
+		}
+	})
+}
+
+func noIgnore(string) bool { return false }
+
+func TestAddRecursivePrunesAndBudgets(t *testing.T) {
+	root := t.TempDir()
+	writeFiles := func(dir string, n int) {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		for i := 0; i < n; i++ {
+			if err := os.WriteFile(filepath.Join(dir, "f"+strconv.Itoa(i)), nil, 0o644); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+
+	t.Run("ignore predicate prunes a subtree", func(t *testing.T) {
+		src := filepath.Join(root, "src")
+		skip := filepath.Join(root, "skipme")
+		writeFiles(src, 1)
+		writeFiles(skip, 1)
+
+		fsw, err := fsnotify.NewWatcher()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer fsw.Close()
+
+		ignore := func(dir string) bool { return filepath.Base(dir) == "skipme" }
+		added, _, err := addRecursive(fsw, root, maxWatchDirs, maxWatchFiles, ignore)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if added != 2 { // root + src; skipme pruned
+			t.Errorf("added = %d, want 2", added)
+		}
+	})
+
+	t.Run("asset-heavy dir is skipped but subdirs still watched", func(t *testing.T) {
+		assets := filepath.Join(root, "assets")
+		writeFiles(assets, maxWatchDirEntries+1)
+		nested := filepath.Join(assets, "nested")
+		writeFiles(nested, 1)
+
+		fsw, err := fsnotify.NewWatcher()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer fsw.Close()
+
+		added, _, err := addRecursive(fsw, filepath.Join(root, "assets"), maxWatchDirs, maxWatchFiles, noIgnore)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if added != 1 { // assets skipped (too many files), nested watched
+			t.Errorf("added = %d, want 1", added)
+		}
+	})
+
+	t.Run("file budget stops the walk", func(t *testing.T) {
+		froot := t.TempDir()
+		for i := 0; i < 3; i++ {
+			writeFiles(filepath.Join(froot, "d"+strconv.Itoa(i)), 3)
+		}
+
+		fsw, err := fsnotify.NewWatcher()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer fsw.Close()
+
+		// fileLimit 5: root(0) + d0(3) + d1(3=6) trips the budget before d2.
+		added, stopped, err := addRecursive(fsw, froot, maxWatchDirs, 5, noIgnore)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !stopped {
+			t.Fatal("stopped = false, want true (file budget hit)")
+		}
+		if added != 3 { // root + d0 + d1; d2 cut by the file budget
+			t.Errorf("added = %d, want 3 (root + d0 + d1 before budget)", added)
 		}
 	})
 }

--- a/server/web/js/i18n.js
+++ b/server/web/js/i18n.js
@@ -231,7 +231,7 @@ var I18N = {
     'ui.system': 'System',
     // Data freshness
     'freshness.last_data': 'Last data: ',
-    'freshness.no_data': 'No data',
+    'freshness.no_data': 'No data in 24h',
     // Errors
     'error.greptimedb': 'Could not reach GreptimeDB: ',
     'error.cc_metrics': 'Could not load Claude Code metrics: ',
@@ -824,7 +824,7 @@ var I18N = {
     'ui.dark': '\u6df1\u8272',
     'ui.system': '\u7cfb\u7edf',
     'freshness.last_data': '\u6700\u540e\u6570\u636e: ',
-    'freshness.no_data': '\u65e0\u6570\u636e',
+    'freshness.no_data': '24 \u5c0f\u65f6\u5185\u65e0\u6570\u636e',
     'error.greptimedb': '\u65e0\u6cd5\u8fde\u63a5 GreptimeDB\uff1a',
     'error.cc_metrics': '\u65e0\u6cd5\u52a0\u8f7d Claude Code \u6307\u6807\uff1a',
     'error.search': '\u641c\u7d22\u9519\u8bef\uff1a',
@@ -1400,7 +1400,7 @@ var I18N = {
     'ui.dark': 'Oscuro',
     'ui.system': 'Sistema',
     'freshness.last_data': '\u00dalt. datos: ',
-    'freshness.no_data': 'Sin datos',
+    'freshness.no_data': 'Sin datos en 24h',
     'error.greptimedb': 'No se pudo conectar a GreptimeDB: ',
     'error.cc_metrics': 'No se pudieron cargar m\u00e9tricas de Claude Code: ',
     'error.search': 'Error de b\u00fasqueda: ',

--- a/server/web/js/views.js
+++ b/server/web/js/views.js
@@ -41,16 +41,19 @@ async function detectDataSources() {
     result.hasCodex = result.codexMetrics.length > 0;
     result.hasOpenClaw = result.ocMetrics.length > 0;
     if (result.hasLogs) {
+      // Existence probes, not aggregates: an unbounded SUM/COUNT over
+      // opentelemetry_logs (>1M rows) blows GreptimeDB's 512MiB per-query
+      // limit. "LIMIT 1" streams and short-circuits — O(1) memory. We can't
+      // add a time bound here: presence is a "has this agent EVER produced
+      // logs" question, and bounding it would drop a view for an agent idle
+      // longer than the window.
       try {
-        var logKindRes = await query(
-          "SELECT " +
-          "SUM(CASE WHEN body LIKE 'claude_code.%' OR scope_name = 'com.anthropic.claude_code.events' THEN 1 ELSE 0 END) AS claude_rows, " +
-          "SUM(CASE WHEN scope_name LIKE 'codex_%' THEN 1 ELSE 0 END) AS codex_rows " +
-          "FROM opentelemetry_logs"
-        );
-        var logKindRow = rows(logKindRes)?.[0] || [];
-        result.hasClaudeLogs = result.hasClaudeLogs || (Number(logKindRow[0]) || 0) > 0;
-        result.hasCodex = result.hasCodex || (Number(logKindRow[1]) || 0) > 0;
+        var logKindRes = await Promise.all([
+          query("SELECT 1 FROM opentelemetry_logs WHERE body LIKE 'claude_code.%' OR scope_name = 'com.anthropic.claude_code.events' LIMIT 1").catch(function() { return null; }),
+          query("SELECT 1 FROM opentelemetry_logs WHERE scope_name LIKE 'codex_%' LIMIT 1").catch(function() { return null; }),
+        ]);
+        result.hasClaudeLogs = result.hasClaudeLogs || (rows(logKindRes[0]) || []).length > 0;
+        result.hasCodex = result.hasCodex || (rows(logKindRes[1]) || []).length > 0;
       } catch { /* ignore */ }
     }
     if (result.hasTraces) {
@@ -66,9 +69,9 @@ async function detectDataSources() {
       if (!result.hasCodex) {
         try {
           var codexTraceRes = await query(
-            "SELECT COUNT(*) AS cnt FROM opentelemetry_traces WHERE service_name = 'codex_cli_rs'"
+            "SELECT 1 FROM opentelemetry_traces WHERE service_name = 'codex_cli_rs' LIMIT 1"
           );
-          result.hasCodex = (Number(rows(codexTraceRes)?.[0]?.[0]) || 0) > 0;
+          result.hasCodex = (rows(codexTraceRes) || []).length > 0;
         } catch { /* ignore */ }
       }
       // Detect OpenClaw via span_name when columns are not yet registered.
@@ -541,8 +544,8 @@ async function checkDataFreshness() {
     // Check both logs and metrics — use whichever is newer
     try {
       var ccResults = await Promise.all([
-        query("SELECT MAX(timestamp) AS last_ts FROM opentelemetry_logs").catch(function() { return null; }),
-        query("SELECT MAX(greptime_timestamp) AS last_ts FROM claude_code_token_usage_tokens_total").catch(function() { return null; }),
+        query("SELECT MAX(timestamp) AS last_ts FROM opentelemetry_logs WHERE timestamp >= now() - INTERVAL '1 day'").catch(function() { return null; }),
+        query("SELECT MAX(greptime_timestamp) AS last_ts FROM claude_code_token_usage_tokens_total WHERE greptime_timestamp >= now() - INTERVAL '1 day'").catch(function() { return null; }),
       ]);
       var ts1 = ccResults[0] && rows(ccResults[0])?.[0]?.[0];
       var ts2 = ccResults[1] && rows(ccResults[1])?.[0]?.[0];
@@ -554,8 +557,8 @@ async function checkDataFreshness() {
   } else if (currentView === 'codex') {
     try {
       var codexResults = await Promise.all([
-        query("SELECT MAX(timestamp) AS last_ts FROM opentelemetry_logs WHERE scope_name LIKE 'codex_%'").catch(function() { return null; }),
-        query("SELECT MAX(greptime_timestamp) AS last_ts FROM codex_turn_token_usage_sum").catch(function() { return null; }),
+        query("SELECT MAX(timestamp) AS last_ts FROM opentelemetry_logs WHERE scope_name LIKE 'codex_%' AND timestamp >= now() - INTERVAL '1 day'").catch(function() { return null; }),
+        query("SELECT MAX(greptime_timestamp) AS last_ts FROM codex_turn_token_usage_sum WHERE greptime_timestamp >= now() - INTERVAL '1 day'").catch(function() { return null; }),
       ]);
       var cTs1 = codexResults[0] && rows(codexResults[0])?.[0]?.[0];
       var cTs2 = codexResults[1] && rows(codexResults[1])?.[0]?.[0];
@@ -567,14 +570,14 @@ async function checkDataFreshness() {
     } catch { el.textContent = ''; el.className = 'data-freshness'; }
     return;
   } else if (currentView === 'openclaw') {
-    sql = "SELECT MAX(timestamp) AS last_ts FROM opentelemetry_traces WHERE span_name LIKE 'openclaw.%'";
+    sql = "SELECT MAX(timestamp) AS last_ts FROM opentelemetry_traces WHERE span_name LIKE 'openclaw.%' AND timestamp >= now() - INTERVAL '1 day'";
   } else if (currentView === 'sessions') {
-    sql = "SELECT MAX(ts) AS last_ts FROM tma1_hook_events";
+    sql = "SELECT MAX(ts) AS last_ts FROM tma1_hook_events WHERE ts >= now() - INTERVAL '1 day'";
   } else if (currentView === 'prompts') {
-    sql = "SELECT MAX(ts) AS last_ts FROM tma1_messages WHERE message_type = 'user'";
+    sql = "SELECT MAX(ts) AS last_ts FROM tma1_messages WHERE message_type = 'user' AND ts >= now() - INTERVAL '1 day'";
   } else if (currentView === 'traces') {
     var cols = await genai_getTraceColumns();
-    sql = "SELECT MAX(timestamp) AS last_ts FROM opentelemetry_traces WHERE " + genaiSpanWhere(cols);
+    sql = "SELECT MAX(timestamp) AS last_ts FROM opentelemetry_traces WHERE (" + genaiSpanWhere(cols) + ") AND timestamp >= now() - INTERVAL '1 day'";
   } else {
     el.textContent = '';
     return;


### PR DESCRIPTION
Two resource/performance fixes found while diagnosing the local tma1 install (server holding ~14k fds; Codex freshness badge throwing a recurring 500).

## 1. `sensor/git`: bound file-watcher fd usage

The git change-sensor recursively registers fsnotify watches over the whole project tree. On macOS fsnotify uses kqueue, which opens **one fd per file** in every watched dir — so fd cost scales with file count, not dir count. The old `maxWatchDirs` cap only bounded directories.

On this machine the watcher held ~14k fds, **~8k of them on gitignored build/cache dirs** (`.gocache`, `.vitepress/cache`) that the recursive walk never pruned — because `.gitignore` was only consulted at event time, not during the walk.

- `addRecursive` now prunes via the project's `.gitignore` **at walk time**, so gitignored build/cache dirs never cost a descriptor.
- Added `maxWatchFiles` (the fd budget that actually matters) alongside `maxWatchDirs`.
- Skip watching any single dir with more than `maxWatchDirEntries` (512) files — asset/content folders — while still descending into subdirs.
- Extended the static ignore list with common generated dirs (`.gocache`, `.gradle`, `.turbo`, `.svelte-kit`, `.nuxt`, `.vitepress/cache`, `.mypy_cache`, `.ruff_cache`, `.terraform`, …).

## 2. `dashboard`: stop full-table scans in freshness/detection queries

`checkDataFreshness` and `detectDataSources` ran unbounded `MAX`/`COUNT`/`SUM` over `opentelemetry_logs` (1.1M rows) and `opentelemetry_traces` (4.2M). `MAX(timestamp) WHERE scope_name LIKE 'codex_%'` **already failed** with GreptimeDB's 512MiB per-query memory limit — the recurring `/api/query 500` behind the Codex freshness badge.

- Freshness `MAX(...)` queries get a fixed `>= now() - INTERVAL '1 day'` bound so the TIME INDEX prunes to the recent partition. Data older than a day already renders as `very-stale`, so **no visible behaviour change**.
- Existence probes (`SUM`/`COUNT ... > 0`) become `SELECT 1 ... LIMIT 1` — streams in O(1) memory instead of aggregating whole history. No time bound here: presence is a "has this agent ever produced data" question.

Measured impact (local DB): the codex freshness query went from OOM-fail to 1ms; the two detection probes from 659ms/58ms to 10ms/2ms.

## Follow-ups (not in this PR)
- `~/Library/Logs/tma1-server.log` never rotates (126MB single file since March; every HTTP request access-logged).
- Stale `~/.tma1/bin/.version` dead file (inert post-#69).
- Longer term, the whole fsnotify tree-watch could be replaced by a `git status --porcelain` poll — fd cost goes to zero and no per-dir heuristics are needed. Larger change; deferred.

## Testing
- `go test -race` on `internal/sensor/git` (added a file-budget cap test + gitignore-prune / asset-skip tests).
- `go build ./...`, `gofmt`, `go vet`, ESLint on `views.js` — all clean.
- Each rewritten SQL verified against the live local GreptimeDB (result parity + timing).