### PR TITLE
chore(greptimedb): pin GreptimeDB to v1.2.0-beta.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ the single `/v1/otlp` base.
 | `TMA1_HOST` | `127.0.0.1` | Address `tma1-server` binds to |
 | `TMA1_PORT` | `14318` | HTTP port for `tma1-server` |
 | `TMA1_DATA_DIR` | `~/.tma1` | Data, config, and binary directory |
-| `TMA1_GREPTIMEDB_VERSION` | `latest` | GreptimeDB version to install |
+| `TMA1_GREPTIMEDB_VERSION` | `v1.2.0-beta.2` | GreptimeDB version to install. Pinned to an exact tag; set to `latest` to track stable releases instead |
 | `TMA1_GREPTIMEDB_HTTP_PORT` | `14000` | GreptimeDB HTTP and OTLP port |
 | `TMA1_GREPTIMEDB_GRPC_PORT` | `14001` | GreptimeDB gRPC port |
 | `TMA1_GREPTIMEDB_MYSQL_PORT` | `14002` | GreptimeDB MySQL protocol port |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -222,7 +222,7 @@ column lists + sample queries that get published with the skill.
 | `TMA1_HOST` | `127.0.0.1` | Address tma1-server binds to |
 | `TMA1_PORT` | `14318` | HTTP port for tma1-server |
 | `TMA1_DATA_DIR` | `~/.tma1` | Directory for GreptimeDB data + binaries |
-| `TMA1_GREPTIMEDB_VERSION` | `latest` | GreptimeDB version to download |
+| `TMA1_GREPTIMEDB_VERSION` | `v1.2.0-beta.2` | GreptimeDB version to download. Pinned to an exact tag; set to `latest` to track stable releases instead |
 | `TMA1_GREPTIMEDB_HTTP_PORT` | `14000` | GreptimeDB HTTP API + OTLP port |
 | `TMA1_GREPTIMEDB_GRPC_PORT` | `14001` | GreptimeDB gRPC port |
 | `TMA1_GREPTIMEDB_MYSQL_PORT` | `14002` | GreptimeDB MySQL protocol port |

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -7,6 +7,11 @@ import (
 	"strconv"
 )
 
+// Pinned rather than "latest" because GitHub's /releases/latest redirect skips
+// pre-releases: "latest" would resolve to an older stable tag and re-download it
+// on every start. Mirrored in site/public/install.sh.
+const defaultGreptimeDBVersion = "v1.2.0-beta.2"
+
 // Config holds all runtime configuration for tma1-server.
 type Config struct {
 	// Host is the address tma1-server binds to (default 127.0.0.1).
@@ -18,7 +23,7 @@ type Config struct {
 	// DataDir is where GreptimeDB binary and data are stored (~/.tma1).
 	DataDir string
 
-	// GreptimeDB version to download ("latest" or "v0.x.y").
+	// GreptimeDB version to download ("latest" or an exact tag).
 	GreptimeDBVersion string
 
 	// GreptimeDB HTTP API port (used for SQL queries, health checks, and OTLP ingestion).
@@ -62,7 +67,7 @@ func Load() (*Config, error) {
 		Host:                env("TMA1_HOST", "127.0.0.1"),
 		Port:                env("TMA1_PORT", "14318"),
 		DataDir:             env("TMA1_DATA_DIR", filepath.Join(home, ".tma1")),
-		GreptimeDBVersion:   env("TMA1_GREPTIMEDB_VERSION", "latest"),
+		GreptimeDBVersion:   env("TMA1_GREPTIMEDB_VERSION", defaultGreptimeDBVersion),
 		GreptimeDBHTTPPort:  envInt("TMA1_GREPTIMEDB_HTTP_PORT", 14000),
 		GreptimeDBGRPCPort:  envInt("TMA1_GREPTIMEDB_GRPC_PORT", 14001),
 		GreptimeDBMySQLPort: envInt("TMA1_GREPTIMEDB_MYSQL_PORT", 14002),

--- a/server/internal/config/config_test.go
+++ b/server/internal/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -29,7 +30,7 @@ func TestLoadDefaults(t *testing.T) {
 		{"Host", cfg.Host, "127.0.0.1"},
 		{"Port", cfg.Port, "14318"},
 		{"DataDir", cfg.DataDir, filepath.Join(home, ".tma1")},
-		{"GreptimeDBVersion", cfg.GreptimeDBVersion, "latest"},
+		{"GreptimeDBVersion", cfg.GreptimeDBVersion, defaultGreptimeDBVersion},
 		{"LogLevel", cfg.LogLevel, "info"},
 	}
 	for _, tt := range tests {
@@ -120,5 +121,21 @@ func TestEnvIntInvalidFallback(t *testing.T) {
 
 	if cfg.GreptimeDBHTTPPort != 14000 {
 		t.Errorf("expected fallback 14000 for invalid int, got %d", cfg.GreptimeDBHTTPPort)
+	}
+}
+
+// install.sh lays down the binary before tma1-server ever runs; on drift the
+// server replaces it on first start — the churn pinning exists to prevent.
+func TestInstallShPinMatchesDefault(t *testing.T) {
+	const script = "../../../site/public/install.sh"
+	data, err := os.ReadFile(script)
+	if err != nil {
+		t.Skipf("install.sh not readable from this checkout: %v", err)
+	}
+
+	want := `TMA1_GREPTIMEDB_VERSION="${TMA1_GREPTIMEDB_VERSION:-` + defaultGreptimeDBVersion + `}"`
+	if !strings.Contains(string(data), want) {
+		t.Errorf("install.sh does not pin %s; expected to find:\n\t%s",
+			defaultGreptimeDBVersion, want)
 	}
 }

--- a/server/internal/install/install.go
+++ b/server/internal/install/install.go
@@ -24,11 +24,10 @@ import (
 const (
 	githubReleaseBase = "https://github.com/GreptimeTeam/greptimedb/releases"
 
-	// minRequiredVersion is the minimum GreptimeDB version that tma1 requires.
-	// When the installed version is older than this, an upgrade is triggered
-	// even if the user configured "latest" (which normally skips network checks).
-	// Bump this when a new GreptimeDB release contains important fixes or
-	// breaking changes that tma1 depends on.
+	// Floor for the "latest" path only; an exact pin is matched exactly instead.
+	// MUST stay a released version: breaching the floor resolves "latest", which
+	// never yields a pre-release, so a pre-release floor is unsatisfiable and
+	// re-downloads forever. Ship pre-releases via config.defaultGreptimeDBVersion.
 	minRequiredVersion = "v1.1.3"
 
 	// Downloading the GreptimeDB archive can legitimately take longer than a
@@ -439,7 +438,7 @@ func verifyChecksum(tarball *os.File, version string, logger *slog.Logger) error
 	if err != nil {
 		return nil // can't build URL, skip
 	}
-	checksumURL := downloadURL + ".sha256sum"
+	checksumURL := checksumURLFor(downloadURL)
 
 	resp, err := versionClient.Get(checksumURL) //nolint:gosec
 	if err != nil {
@@ -452,13 +451,20 @@ func verifyChecksum(tarball *os.File, version string, logger *slog.Logger) error
 		return nil
 	}
 
+	// The file is per-archive, so it holds a bare hash with no filename column.
+	// Still accept the two-column `sha256sum` layout in case that changes.
 	scanner := bufio.NewScanner(resp.Body)
 	var expectedHash string
 	filename := filepath.Base(downloadURL)
 	for scanner.Scan() {
 		fields := strings.Fields(scanner.Text())
-		if len(fields) >= 2 && strings.HasSuffix(fields[1], filename) {
+		switch {
+		case len(fields) == 1 && isSHA256(fields[0]):
 			expectedHash = fields[0]
+		case len(fields) >= 2 && strings.HasSuffix(fields[1], filename):
+			expectedHash = fields[0]
+		}
+		if expectedHash != "" {
 			break
 		}
 	}
@@ -481,6 +487,22 @@ func verifyChecksum(tarball *os.File, version string, logger *slog.Logger) error
 	}
 	logger.Info("checksum verified", "sha256", actualHash[:16]+"...")
 	return nil
+}
+
+// Releases publish greptime-<os>-<arch>-<version>.sha256sum, i.e. the archive
+// name with .tar.gz replaced, not suffixed. Appending 404s on every release,
+// which verifyChecksum treats as "unavailable" and skips — silently disabling
+// verification with no failure signal.
+func checksumURLFor(downloadURL string) string {
+	return strings.TrimSuffix(downloadURL, ".tar.gz") + ".sha256sum"
+}
+
+func isSHA256(s string) bool {
+	if len(s) != sha256.Size*2 {
+		return false
+	}
+	_, err := hex.DecodeString(s)
+	return err == nil
 }
 
 // extractBinary finds the `greptime` binary inside a .tar.gz and writes it to destPath.

--- a/server/internal/install/install_test.go
+++ b/server/internal/install/install_test.go
@@ -415,3 +415,32 @@ func TestVerifyChecksumLogic(t *testing.T) {
 		}
 	})
 }
+
+// A pre-release floor is unsatisfiable: breaching it resolves "latest", which
+// never yields a pre-release, so every start re-downloads the same stable tag.
+func TestMinRequiredVersionIsNotAPreRelease(t *testing.T) {
+	_, _, _, pre, ok := parseSemver(minRequiredVersion)
+	if !ok {
+		t.Fatalf("minRequiredVersion %q is not parseable semver", minRequiredVersion)
+	}
+	if pre != "" {
+		t.Fatalf("minRequiredVersion %q is a pre-release (%q); resolveVersion(%q) can never satisfy it, "+
+			"so every start would re-download. Pin config.defaultGreptimeDBVersion instead.",
+			minRequiredVersion, pre, "latest")
+	}
+}
+
+// Guards the silent-failure shape: a wrong checksum URL 404s, and verifyChecksum
+// treats any non-200 as "unavailable" and skips, so the mistake never surfaces.
+func TestChecksumURLDropsArchiveSuffix(t *testing.T) {
+	url, err := buildDownloadURL("v1.2.0-beta.2", "linux", "amd64")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := checksumURLFor(url)
+	want := "https://github.com/GreptimeTeam/greptimedb/releases/download/" +
+		"v1.2.0-beta.2/greptime-linux-amd64-v1.2.0-beta.2.sha256sum"
+	if got != want {
+		t.Errorf("checksumURLFor(%s)\n got %s\nwant %s", url, got, want)
+	}
+}

--- a/site/public/install.sh
+++ b/site/public/install.sh
@@ -30,7 +30,11 @@ REPO="tma1-ai/tma1"
 INSTALL_DIR="${TMA1_INSTALL_DIR:-$HOME/.tma1/bin}"
 TMA1_PORT="${TMA1_PORT:-14318}"
 TMA1_FORCE="${TMA1_FORCE:-0}"
-TMA1_GREPTIMEDB_VERSION="${TMA1_GREPTIMEDB_VERSION:-latest}"
+# Exact GreptimeDB tag tma1 ships against. Keep in sync with
+# defaultGreptimeDBVersion in server/internal/config/config.go. Pinned rather
+# than "latest" because the shipped release is a pre-release, which "latest"
+# never resolves to. Set TMA1_GREPTIMEDB_VERSION=latest to track stable instead.
+TMA1_GREPTIMEDB_VERSION="${TMA1_GREPTIMEDB_VERSION:-v1.2.0-beta.2}"
 # Adapter(s) to wire into agents. Empty = skip. Accepts a comma-separated list
 # or the alias `all` (= claude-code,codex). Each adapter registers hooks, MCP,
 # and the /tma1-peer skill globally. Project-local files are skipped here —
@@ -126,8 +130,10 @@ download() {
 }
 
 # --- Download GreptimeDB binary via official install script ---
-# Minimum GreptimeDB version required by TMA1. Keep in sync with
-# minRequiredVersion in server/internal/install/install.go.
+# Minimum GreptimeDB version required by TMA1, applied only when
+# TMA1_GREPTIMEDB_VERSION=latest. Keep in sync with minRequiredVersion in
+# server/internal/install/install.go, which carries the same released-only
+# constraint.
 MIN_GREPTIMEDB_VERSION="1.1.3"
 
 # version_lt returns 0 (true) if $1 < $2.
@@ -165,17 +171,30 @@ EOF
 download_greptimedb() {
   local greptime_bin="${INSTALL_DIR}/greptime"
   if [ -f "$greptime_bin" ] && [ "$TMA1_FORCE" != "1" ]; then
-    # Check if the installed version meets the minimum requirement.
     local installed_ver
     installed_ver=$("$greptime_bin" --version 2>/dev/null | grep '^[[:space:]]*version:' | awk '{print $2}' || true)
-    if [ -n "$installed_ver" ] && ! version_lt "$installed_ver" "$MIN_GREPTIMEDB_VERSION"; then
-      info "GreptimeDB ${installed_ver} already installed (>= ${MIN_GREPTIMEDB_VERSION}), skipping download."
-      return
-    fi
-    if [ -n "$installed_ver" ]; then
+    if [ -z "$installed_ver" ]; then
+      info "Cannot determine GreptimeDB version, upgrading..."
+    elif [ "$TMA1_GREPTIMEDB_VERSION" = "latest" ]; then
+      # Tracking stable: a floor check is all we can do, since we don't know
+      # which tag "latest" will resolve to until the official script runs.
+      if ! version_lt "$installed_ver" "$MIN_GREPTIMEDB_VERSION"; then
+        info "GreptimeDB ${installed_ver} already installed (>= ${MIN_GREPTIMEDB_VERSION}), skipping download."
+        return
+      fi
       info "GreptimeDB ${installed_ver} is below minimum ${MIN_GREPTIMEDB_VERSION}, upgrading..."
     else
-      info "Cannot determine GreptimeDB version, upgrading..."
+      # Pinned to an exact tag: match exactly, mirroring checkVersionMismatch in
+      # server/internal/install/install.go. A floor check would wrongly skip the
+      # download whenever the pin is a pre-release of a higher version than the
+      # installed binary (e.g. installed 1.1.3, pinned v1.2.0-beta.2 with the
+      # floor still at 1.1.3). Both sides are normalised to a 'v' prefix because
+      # `greptime --version` reports a bare semver.
+      if [ "v${installed_ver#v}" = "v${TMA1_GREPTIMEDB_VERSION#v}" ]; then
+        info "GreptimeDB ${installed_ver} already installed (pinned), skipping download."
+        return
+      fi
+      info "GreptimeDB ${installed_ver} does not match pinned ${TMA1_GREPTIMEDB_VERSION}, installing..."
     fi
   fi
 


### PR DESCRIPTION
Upgrades the shipped GreptimeDB to `v1.2.0-beta.2`, plus a checksum fix found on the way.

## Why pin instead of raising the floor

`minRequiredVersion` only applies on the `latest` path, and GitHub's `/releases/latest` redirect never resolves to a pre-release — it currently returns `v1.1.4`. Raising the floor to `v1.2.0-beta.2` would make every start find the installed binary below the floor, resolve `latest` to v1.1.4, install it, and repeat **forever** — the same shape as the old `.version` ledger bug.

So the default `TMA1_GREPTIMEDB_VERSION` is pinned to the exact tag instead. That routes `checkVersionMismatch` through its exact-match path, which converges after one upgrade. `minRequiredVersion` stays at `v1.1.3` for users who explicitly set `latest`, with a test asserting it never becomes a pre-release.

`install.sh` gets the matching exact-match branch — a floor check there would have skipped the upgrade entirely for anyone on v1.1.3.

## Checksum fix (separate commit)

Releases publish `greptime-<os>-<arch>-<version>.sha256sum` — the archive name with `.tar.gz` **replaced**, not suffixed. `verifyChecksum` appended, so the request 404'd on every release and was treated as "checksum file unavailable, skipping". **SHA-256 verification has never actually run.** The file also holds a bare hash with no filename column, which the two-field parser rejected. Both are fixed.

## Verification

Ran a live `v1.2.0-beta.2` against the real `standalone.toml` and the production `opentelemetry_traces` schema, with `v1.1.3` as a control:

| | v1.1.3 | v1.2.0-beta.2 |
|---|---|---|
| Health / config warnings | 200 / none | 200 / none |
| Init paths (8) | all OK | all OK |
| Flows created | 4 | 4 (identical) |
| `tma1_*` tables | 12 | 12 (identical) |

- Pin convergence driven through `checkVersionMismatch` with both real binaries: pinned+beta.2 → no upgrade; pinned+v1.1.3 → upgrade to pin; latest+either → no upgrade.
- Download URLs return 200 on all 5 supported platforms (Windows relies on this path exclusively — `install.ps1` does not install GreptimeDB).
- Checksum: genuine archive verifies, corrupted archive rejected.
- `go vet`, `golangci-lint`, `go test -race` over `./cmd/... ./internal/...`, `shellcheck install.sh` — all clean.