### PR TITLE
docs(readme): add release, CI, license, and platform badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 # TMA1
 
+<!-- include_prereleases is required: every TMA1 release so far is a
+     pre-release, and without it the badge renders "no releases found".
+     Leave sort at the default (date) — semver sort compares the
+     pre-release identifier lexically, which orders alpha9 above alpha14. -->
+[![Release](https://img.shields.io/github/v/release/tma1-ai/tma1?include_prereleases&label=release&color=orange)](https://github.com/tma1-ai/tma1/releases)
+[![CI](https://github.com/tma1-ai/tma1/actions/workflows/ci.yml/badge.svg)](https://github.com/tma1-ai/tma1/actions/workflows/ci.yml)
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue)](LICENSE)
+![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows-lightgrey)
+
 > A monolith for your agent's loop. Silent until it talks back.
 
 TMA1 is local-first observability for LLM agents, powered by GreptimeDB.


### PR DESCRIPTION
Adds four badges to the README, with the latest version visible even though it is a pre-release.

The release badge needs `include_prereleases`. Every TMA1 release so far is a pre-release, so the default badge renders `no releases or repo not found` in red — verified against the live shields endpoint:

```
.../github/v/release/tma1-ai/tma1.json                      -> "no releases or repo not found"
.../github/v/release/tma1-ai/tma1.json?include_prereleases  -> "v0.2.0-alpha14"
```

Sort deliberately stays at the default (`date`) rather than `semver`: semver sort compares the pre-release identifier lexically, which ranks `alpha9` above `alpha14`.

No GreptimeDB version badge — it would be a third place to hand-sync the pinned tag, on top of `config.go` and `install.sh`.

All four badge endpoints verified to resolve.