### PR TITLE
fix(sensor): avoid false human file attribution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,10 +129,10 @@ tools: Bash×18, Edit×12, Read×9, TaskUpdate×4
 recent_files: .../perception/peer.go, .../mcp/tools.go, .../hooks/install_cc.go
 build: make (running)
 build_last_error (6m ago, may have recovered): exit code 1 ...
-external_human_changes: 3
+external_changes: 3
 external_files: .../path/to/file.go
 anomalies:
-  - [MEDIUM] human_modified_during_session — Re-read the listed files before assuming your in-memory copy is current.
+  - [MEDIUM] external_modified_during_session — Re-read the listed files before assuming your in-memory copy is current.
 </tma1-context>
 ```
 

--- a/clawhub-skill/tma1/REFERENCE.md
+++ b/clawhub-skill/tma1/REFERENCE.md
@@ -27,7 +27,7 @@ Check which tables exist:
 - `tma1_messages` → conversation content for all agents (session_id prefixes: `cp:` Copilot CLI, `oc:` OpenClaw; Claude Code and Codex use raw session IDs)
 - `tma1_anomaly_emits` → ground-truth log of which anomalies were emitted to which agent session, used by the dashboard's Anomalies tab and the Phase 1.7 validation gates
 - `tma1_build_events` → output of `tma1-server build -- <cmd>` (one-shot or `--watch`): stdout / stderr / completion events with exit code, duration, and last error
-- `tma1_external_changes` → file system + git activity captured by the git/file sensor (agent vs human attribution)
+- `tma1_external_changes` → file system + git activity captured by the git/file sensor (observed agent writes vs. unknown source)
 - `tma1_project_state` → most recent indexed snapshot of each project's structure (language, build / test system, key files, top-level directories)
 
 ---
@@ -171,15 +171,15 @@ File system + git activity outside the agent. 8 columns, `append_mode`.
 | `change_type` | STRING | INVERTED INDEX (`file_modified`, `file_added`, `file_deleted`, `git_commit`, `git_branch_switch`) |
 | `file_path` | STRING NULL | populated for file-system events |
 | `git_sha`, `git_message` | STRING NULL | populated for `git_*` events |
-| `attribution` | STRING NULL | INVERTED INDEX (`agent` / `human` / `unknown`) — derived by HookAttributor: agent if a Pre/PostToolUse Edit/Write/MultiEdit/Bash event within ±5 s mentions the same path; otherwise human |
+| `attribution` | STRING NULL | INVERTED INDEX (`agent` / `unknown`; historical rows may contain `human`) — `HookAttributor` uses exact paths and active intervals from mutating tools to recognize observed agent writes. Other changes remain `unknown`. |
 | `host` | STRING NULL | hostname |
 
-Files a human modified in the last 30 min:
+Files changed outside observed agent writes in the last 30 min:
 
 ```sql
 SELECT ts, file_path FROM tma1_external_changes
 WHERE project = '<project>'
-  AND attribution = 'human'
+  AND attribution IN ('human','unknown')
   AND change_type IN ('file_modified','file_added')
   AND ts > now() - INTERVAL '30 minutes'
 ORDER BY ts DESC
@@ -244,9 +244,9 @@ GROUP BY b.project
 ORDER BY last_event_at DESC
 ```
 
-**Files a human modified during the active session
+**Files changed outside observed agent writes during the active session
 (joins `tma1_hook_events` to find the session window, then
-`tma1_external_changes` for human edits in that window):**
+`tma1_external_changes` for external changes in that window):**
 
 ```sql
 WITH win AS (
@@ -255,7 +255,7 @@ WITH win AS (
 )
 SELECT ec.ts, ec.file_path
 FROM tma1_external_changes ec, win
-WHERE ec.attribution = 'human'
+WHERE ec.attribution IN ('human','unknown')
   AND ec.change_type IN ('file_modified','file_added')
   AND ec.ts BETWEEN win.started_ms AND win.ended_ms
 ORDER BY ec.ts DESC
@@ -687,7 +687,7 @@ ORDER BY p95_ms DESC
 | Agent suddenly can't see `mcp__tma1__*` tools / "Connection closed" | MCP stdio child died or stalled. In Claude Code: `/mcp` to reconnect. In Codex: restart the session. Confirm the parent is still up via `pgrep -fl tma1-server`; if it isn't, restart it and the MCP child respawns automatically |
 | `<tma1-context>` block not appearing in prompts | `UserPromptSubmit` hook isn't registered. CC: `jq '.hooks.UserPromptSubmit' ~/.claude/settings.json` (expect a non-empty array containing `id: "tma1"`). Codex: `jq '.hooks.UserPromptSubmit' ~/.codex/hooks.json`. If empty, re-run `tma1-server install --adapter claude-code` (or `--adapter codex`) |
 | Anomalies exist in dashboard but never reach the agent | Either the hook fires beyond the 300ms injection budget (GreptimeDB is slow — check `~/.tma1/config/standalone.toml` resource limits, the response falls back to empty silently), or the hook script isn't running at all. Run `~/.tma1/hooks/tma1-hook.sh` manually with `{"hook_event_name":"UserPromptSubmit","session_id":"test"}` on stdin; non-empty stdout means the path works |
-| `get_external_changes` response contains `partial_error` field | One of two underlying GreptimeDB queries failed; the partial snapshot in `human_changes` / `git_changes` is still valid. Usually transient — retry. Persistent → check DB health |
+| `get_external_changes` response contains `partial_error` field | One of two underlying GreptimeDB queries failed; the partial snapshot in `external_changes` / `git_changes` is still valid. Usually transient — retry. Persistent → check DB health |
 | Shutdown logs `writeq drain timed out, some background writes may have been dropped` | The 2-second drain budget elapsed before background INSERTs landed. Last few hook events / anomaly emits lost. Acceptable on rare shutdown; recurrent → GreptimeDB under-resourced |
 | `.tma1-context.md` not updating | This file callback is **opt-in** (designed for non-MCP agents like Aider / Cursor). Set `TMA1_ENABLE_FILE_CALLBACK=1` on the tma1-server process and restart. If still missing after enabling, verify the project root resolver picked a writable directory: server log shows `tma1-context.md refresh failed` at Debug level on failure |
 | Same anomaly injected over and over within one session | InjectionCache (1h TTL) should dedupe by Channel. If this happens it's a bug — open an issue with the anomaly `Kind` and the duplicated `<tma1-context>` blocks attached |

--- a/clawhub-skill/tma1/SKILL.md
+++ b/clawhub-skill/tma1/SKILL.md
@@ -150,7 +150,7 @@ agent pulls state on demand:
 | `get_session_state` | Recovering action history | Tool calls, tokens, current focus, recent files |
 | `get_anomalies` | Before changing approach | Active anomalies, post-suppression |
 | `get_build_status` | After suggesting edits | Last exit, errors in last 30 min, latest stderr line |
-| `get_external_changes` | After a long break | Human-attributed file edits + git activity |
+| `get_external_changes` | After a long break | File changes outside observed agent writes + git activity |
 | `get_project_state` | First time in an unfamiliar repo | Language / build / test / key files / top-level dirs |
 | `get_peer_sessions` | User asks "what did Codex / CC / OpenClaw / Copilot just do" or invokes `/tma1-peer` | Recent peer-agent sessions on the same project |
 
@@ -164,11 +164,11 @@ routes to a specific channel so the same finding never injects twice:
 
 | Kind | Trigger | Channel |
 | --- | --- | --- |
-| `stale_file_view` | Agent edits a file a human modified externally after the agent's last Read | `user_prompt_submit` |
+| `stale_file_view` | Agent edits a file that changed externally after the agent's last Read | `user_prompt_submit` |
 | `build_broken_after_my_edit` | Build/test failure naming a just-edited file | `stop_block` when ≥3 failures, else `user_prompt_submit` |
 | `repeated_failed_build` | Same Bash prefix failed 3+ times in 30 min | `stop_block` |
 | `test_stuck` | Same test-runner prefix failed 3+ times (go test / cargo test / pytest / jest / mocha / rspec / phpunit / mix test) | `user_prompt_submit` |
-| `human_modified_during_session` | Human-attributed changes during the active session | `user_prompt_submit` |
+| `external_modified_during_session` | Files changed outside observed agent writes during the active session | `user_prompt_submit` |
 | `context_pressure` | Session input tokens cross threshold (default 100k; override via `TMA1_CONTEXT_PRESSURE_THRESHOLD`) | `user_prompt_submit` |
 
 Per-session 10-minute suppression dedupes repeat emits. Resolution

--- a/docs/anomalies.md
+++ b/docs/anomalies.md
@@ -21,11 +21,11 @@ digest, once in the block reason).
 
 | Kind | Severity | Channel | Triggers when |
 |------|----------|---------|---------------|
-| `stale_file_view` | high | user_prompt_submit | Agent Edited file F where the latest Read of F was before a human external change of F. See [Plan scenario](#r-stale-view) below. |
+| `stale_file_view` | high | user_prompt_submit | Agent Edited file F where the latest Read of F was before an external change of F. See [Plan scenario](#r-stale-view) below. |
 | `build_broken_after_my_edit` | high if ≥3 failures, else medium | stop_block (HIGH) / user_prompt_submit (MEDIUM) | Agent edited file F in the last 30 min, then a Bash PostToolUseFailure within ±10 min mentioned F's basename in input or output. |
 | `repeated_failed_build` | high | stop_block | Same Bash command prefix (first 60 chars) failed 3+ times in the last 30 min. |
 | `test_stuck` | medium | user_prompt_submit | Same test identifier (regex-extracted from "FAIL …") appeared in Bash PostToolUseFailure output 3+ times in the last 30 min. |
-| `human_modified_during_session` | medium | user_prompt_submit | At least one human-attributed external change on this project within the session's window, and the changes are no older than 30 min. |
+| `external_modified_during_session` | medium | user_prompt_submit | At least one file changed outside observed agent writes on this project within the session window, and the change is no older than 30 min. |
 | `context_pressure` | medium | user_prompt_submit | `SUM(input_tokens) >= TMA1_CONTEXT_PRESSURE_THRESHOLD` (default 100,000 ≈ 50% of Claude Sonnet's 200k window). One-shot per session. |
 
 ### R-stale-view
@@ -34,7 +34,7 @@ Plan scenario:
 
 ```
 T1 — agent Reads foo.go
-T2 — human modifies foo.go externally   (T2 > T1)
+T2 — foo.go changes externally          (T2 > T1)
 T3 — agent Edits foo.go with no Re-Read in (T2, T3)
 ```
 
@@ -66,7 +66,7 @@ serialise concurrent `Detect` calls.
 | `build_broken_after_my_edit` | Any PostToolUse Bash (non-failure) after the last emit. |
 | `repeated_failed_build` | Same as above. |
 | `test_stuck` | Same as above. |
-| `human_modified_during_session` | None — time-based decay (30 min). |
+| `external_modified_during_session` | None — time-based decay (30 min). |
 | `context_pressure` | None — one-shot per session. |
 
 ## Emit log

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -19,7 +19,7 @@ file index. Read this when you need to know *where* something is or
 | `server/internal/transcript/` | JSONL transcript watcher (Claude Code) + Codex / OpenClaw / Copilot CLI session log parsers |
 | `server/internal/perception/` | v2 perception layer: bundler, anomaly detector (6 rules + channel routing + 10-min suppression + resolvers), incremental injection cache, peer-session reader, file writer for `.tma1-context.md` |
 | `server/internal/sensor/build/` | `tma1-server build [--watch] -- <cmd>` subprocess capture: stdout/stderr tee + batched writes into `tma1_build_events`, force-colour env injection |
-| `server/internal/sensor/git/` | fsnotify file watcher + 30 s git poll + agent-vs-human attribution honouring `.gitignore` + static ignore list; writes `tma1_external_changes` |
+| `server/internal/sensor/git/` | fsnotify file watcher + 30 s git poll + agent-write attribution honoring `.gitignore` + static ignore list; writes `tma1_external_changes` |
 | `server/internal/sensor/project/` | Lazy project-state indexer (language / build / test / key files / top-level dirs) with 24 h TTL gate; writes `tma1_project_state` |
 | `server/internal/mcp/` | JSON-RPC 2.0 stdio MCP server (7 tools backed by the perception bundler) — runs as a child of each agent (CC, Codex) via `tma1-server mcp-serve`. Pull-channel tools (`get_anomalies`) use side-effect-free `DetectPreview` so reading state can't silently consume the suppression window and weaken the next Stop block. |
 | `server/internal/writeq/` | Bounded write semaphore (max-in-flight cap, drop counter, recovered-panic counter) used by hook ingest + anomaly emit to keep GreptimeDB from being fork-bombed |
@@ -210,7 +210,7 @@ so they exist before any trace data arrives). All append-only. The
 | `tma1_messages` | Conversation content: user/assistant/thinking messages, tool_use/tool_result. Base DDL in `flows.go`; v1 migration adds `input_tokens` / `output_tokens` / `cache_read_tokens` / `cache_creation_tokens` / `duration_ms`. 13 columns total. FULLTEXT INDEX on `content` (bloom backend, English analyzer) for keyword search via `matches_term()`. |
 | `tma1_anomaly_emits` | One row per anomaly the Detector emitted to an injection channel — the ground-truth feed for the Anomalies dashboard view and the `/api/anomalies/{budget,follow-rate}` validation gates. Created by `InitAnomalyEmitsTable`. DDL in `anomaly_emits.go`. 9 columns: `ts`, `session_id`, `kind`, `severity`, `"channel"`, `evidence`, `suggestion`, `related_files` (JSON array), `first_emitted_at`. |
 | `tma1_build_events` | stdout/stderr/completion events captured by `tma1-server build [--watch] -- <cmd>`. Created by `InitBuildTable`. DDL in `build.go`. 13 columns including FULLTEXT-indexed `"message"`, `exit_code`, `duration_ms`, `"tag"`. |
-| `tma1_external_changes` | File system + git events captured by the git/file sensor; `attribution = agent / human / unknown` set by `HookAttributor` (looks for an Edit/Write/MultiEdit/Bash hook event within ±5 s mentioning the same path). Created by `InitExternalChangesTable`. DDL in `external.go`. 8 columns. |
+| `tma1_external_changes` | File system + git events captured by the git/file sensor; `attribution = agent / unknown` is set by `HookAttributor`. Exact-path correlation and project-scoped active-tool intervals recognize observed writes from mutating tools. Other changes remain `unknown`. Created by `InitExternalChangesTable`. DDL in `external.go`. 8 columns. |
 | `tma1_project_state` | Latest project structure snapshot (language, build/test system, key files, top-level dirs). Created by `InitProjectStateTable`. DDL in `project.go`. 9 columns including reserved-keyword-quoted `"root"` / `"language"`. Lazy refresh, 24 h TTL gate. |
 | `tma1_schema_version` | Migration ledger: one row per applied `Migration` (version, description, ts). Created on demand by `RunSchemaMigrations`. Internal — not for agent queries. |
 
@@ -266,7 +266,7 @@ column lists + sample queries that get published with the skill.
 | Incremental injection cache | `server/internal/perception/injection_cache.go` — per-session digest dedupe so identical context isn't re-emitted every turn |
 | MCP stdio server | `server/internal/mcp/server.go` (concurrent loop, write-mutex serialised) + `tools.go` (7 ToolHandlers) + `protocol.go` (JSON-RPC + MCP types) |
 | Build sensor | `server/internal/sensor/build/capture.go` (Runner / LongRunner) + `store.go` (writes `tma1_build_events`) |
-| Git/file sensor | `server/internal/sensor/git/sensor.go` (per-project watcher lifecycle) + `watcher.go` (fsnotify + git poll) + `gitignore.go` + `attribution.go` (agent vs human) + `store.go` |
+| Git/file sensor | `server/internal/sensor/git/sensor.go` (per-project watcher lifecycle) + `watcher.go` (fsnotify + git poll) + `gitignore.go` + `attribution.go` (observed agent writes vs. unknown source) + `store.go` |
 | Project sensor | `server/internal/sensor/project/sensor.go` (TTL-gated indexer) + `indexer.go` (marker-file heuristics) + `store.go` |
 | Schema migrations | `server/internal/greptimedb/schema_migrations.go` — `[]Migration` + ledger DDL |
 | Write semaphore | `server/internal/writeq/sem.go` |

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -39,10 +39,10 @@ tools: Bash×18, Edit×12, Read×9, TaskUpdate×4
 recent_files: .../perception/peer.go, .../mcp/tools.go, .../hooks/install_cc.go
 build: make (running)
 build_last_error (6m ago, may have recovered): exit code 1 ...
-external_human_changes: 3
+external_changes: 3
 external_files: .../path/to/file.go
 anomalies:
-  - [MEDIUM] human_modified_during_session — Re-read the listed files before assuming your in-memory copy is current.
+  - [MEDIUM] external_modified_during_session — Re-read the listed files before assuming your in-memory copy is current.
 </tma1-context>
 ```
 
@@ -58,16 +58,15 @@ anomalies:
 | `recent_files` | Up to 5 most recently touched files | No Edit/Write yet |
 | `build` | `make` running / last exit / never invoked | Build sensor never ran |
 | `build_last_error` | Excerpt of stderr from the most recent failed build, with `may have recovered` flag if newer build is green | No build error in session window |
-| `external_human_changes` | Count of file changes attributed to the human (vs. agent) during the session | No human writes detected |
-| `external_files` | Up to 3 paths the human touched outside the agent | Same as above |
+| `external_changes` | Count of file changes not attributed to observed agent writes during the session | No external changes detected |
+| `external_files` | Up to 3 paths changed outside observed agent writes | Same as above |
 | `anomalies` | List of `[SEVERITY] kind — suggestion` lines from the Detector | No active anomalies |
 
 **Why fields suppress when empty:** the block is injected at every
 user turn — keeping it tight (under ~20 lines typically) preserves the
-agent's context budget. The `external_files` row only appears when
-the human has edited files behind the agent's back, because that's
-the case where the agent must invalidate its in-memory snapshot
-before reading.
+agent's context budget. The `external_files` row only appears when files
+changed outside observed agent writes, because the agent must invalidate its
+in-memory snapshot before continuing.
 
 ## Hook script protocol
 

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -39,7 +39,7 @@ switched directories, or as a "what does TMA1 know right now" probe.
 ## get_session_state
 
 Full state for one session: tool history aggregates, token usage,
-current focus, recent files, last build error, external human changes
+current focus, recent files, last build error, external changes
 during the session.
 
 | Arg | Type | Default | Description |
@@ -84,7 +84,7 @@ the agent doesn't act on a stale failure).
 ## get_external_changes
 
 Files modified outside the agent loop, plus git commits and branch
-moves, classified as `human` or `agent` attribution.
+moves, classified as observed `agent` writes or `unknown` source.
 
 | Arg | Type | Default | Description |
 |-----|------|---------|-------------|

--- a/server/internal/greptimedb/external.go
+++ b/server/internal/greptimedb/external.go
@@ -8,12 +8,12 @@ import (
 
 // externalChangesTableDDL creates tma1_external_changes.
 //
-// Captures file-system + git events for any project the agent has touched,
-// so the perception layer can tell an agent "while you were away, a human
-// modified src/auth.rs and committed README.md". Append-only.
+// Captures file-system + git events for any project the agent has touched, so
+// the perception layer can report changes outside observed agent writes.
+// Append-only.
 //
 // project + change_type + attribution are the dominant filters (every
-// R-stale-view / R-human-modified query uses all three) and all are
+// R-stale-view / R-external-modified query uses all three) and all are
 // low-cardinality. Make them PRIMARY KEY for locality per the
 // GreptimeDB design-table guide.
 var externalChangesTableDDL = `CREATE TABLE IF NOT EXISTS tma1_external_changes (

--- a/server/internal/handler/anomalies.go
+++ b/server/internal/handler/anomalies.go
@@ -229,7 +229,7 @@ func (s *Server) handleAnomaliesBudget(w http.ResponseWriter, r *http.Request) {
 // session, the agent ran a Read tool against a file listed in the
 // anomaly's related_files. This is the canonical action for the
 // related-file rules (stale_file_view, build_broken_after_my_edit,
-// human_modified_during_session). Rules without related_files are
+// external_modified_during_session). Rules without related_files are
 // returned with status="no-signal" so Dennis can see the denominator
 // without misinterpreting a zero rate.
 //

--- a/server/internal/hooks/install_shared.go
+++ b/server/internal/hooks/install_shared.go
@@ -388,10 +388,10 @@ tools: Bash×18, Edit×12, Read×9, TaskUpdate×4
 recent_files: .../perception/peer.go, .../mcp/tools.go, .../hooks/install_cc.go
 build: make (running)
 build_last_error (6m ago, may have recovered): exit code 1 ...
-external_human_changes: 3
+external_changes: 3
 external_files: .../path/to/file.go
 anomalies:
-  - [MEDIUM] human_modified_during_session — Re-read the listed files before assuming your in-memory copy is current.
+  - [MEDIUM] external_modified_during_session — Re-read the listed files before assuming your in-memory copy is current.
 </tma1-context>
 ` + "```" + `
 

--- a/server/internal/mcp/tools.go
+++ b/server/internal/mcp/tools.go
@@ -320,9 +320,9 @@ func (t ProjectStateTool) Call(ctx context.Context, _ map[string]any) (CallToolR
 	return CallToolResult{Content: []ContentBlock{{Type: "text", Text: string(out)}}}, nil
 }
 
-// ExternalChangesTool returns recent human-attributed file modifications
-// and git activity in the current project — what changed while the agent
-// wasn't looking. Default window: last 30 minutes; override via `since_min`.
+// ExternalChangesTool returns recent file modifications not attributed to an
+// agent and git activity in the current project. Default window: last 30
+// minutes; override via `since_min`.
 type ExternalChangesTool struct {
 	Bundler *perception.Bundler
 }
@@ -330,8 +330,8 @@ type ExternalChangesTool struct {
 func (t ExternalChangesTool) Definition() Tool {
 	return Tool{
 		Name: "get_external_changes",
-		Description: "List files modified by a human + git commits / branch " +
-			"switches that happened in the current project recently. Use this " +
+		Description: "List file changes not attributed to an agent, plus git commits " +
+			"and branch switches in the current project. Use this " +
 			"before continuing work after a context refresh to learn what " +
 			"changed outside of your edits.",
 		InputSchema: InputSchema{
@@ -381,7 +381,7 @@ func (t ExternalChangesTool) Call(ctx context.Context, args map[string]any) (Cal
 	// Partial result: when one of the two underlying queries failed but
 	// the other returned rows, GetExternalChanges returns both. Attach
 	// the error message as a top-level partial_error field so the
-	// success shape (project / human_changes / git_changes / counts at
+	// success shape (project / external_changes / git_changes / counts at
 	// the top level) stays stable for downstream consumers.
 	if err != nil {
 		changes.PartialError = err.Error()

--- a/server/internal/perception/anomaly.go
+++ b/server/internal/perception/anomaly.go
@@ -280,12 +280,12 @@ type ruleFunc func(ctx context.Context, sessionID string) ([]Anomaly, error)
 // downstream consumers (suppression, UI) key on.
 func (d *Detector) rules() map[string]ruleFunc {
 	return map[string]ruleFunc{
-		"build_broken_after_my_edit":     d.ruleBuildBrokenAfterMyEdit,
-		"repeated_failed_build":          d.ruleRepeatedFailedBuild,
-		"stale_file_view":                d.ruleStaleFileView,
-		"test_stuck":                     d.ruleTestStuck,
-		"human_modified_during_session":  d.ruleHumanModifiedDuringSession,
-		"context_pressure":               d.ruleContextPressure,
+		"build_broken_after_my_edit":       d.ruleBuildBrokenAfterMyEdit,
+		"repeated_failed_build":            d.ruleRepeatedFailedBuild,
+		"stale_file_view":                  d.ruleStaleFileView,
+		"test_stuck":                       d.ruleTestStuck,
+		"external_modified_during_session": d.ruleExternalModifiedDuringSession,
+		"context_pressure":                 d.ruleContextPressure,
 	}
 }
 
@@ -301,7 +301,7 @@ type resolverFunc func(ctx context.Context, sessionID string, a Anomaly, lastEmi
 // nil when the anomaly has no programmatic "resolved" signal (e.g.
 // context_pressure has no resolver — it simply stops firing once occupancy
 // recedes, e.g. after the agent compacts history, and otherwise re-emits
-// after the silence window; human_modified_during_session decays purely
+// after the silence window; external_modified_during_session decays purely
 // by time).
 func (d *Detector) resolverFor(kind string) resolverFunc {
 	switch kind {
@@ -638,7 +638,7 @@ func firstErrorLine(raw string) string {
 func (d *Detector) ruleStaleFileView(ctx context.Context, sessionID string) ([]Anomaly, error) {
 	// Plan scenario (Phase 1.7):
 	//   T1 — agent Read foo.go
-	//   T2 — human modifies foo.go externally  (T2 > T1)
+	//   T2 — foo.go changes externally          (T2 > T1)
 	//   T3 — agent Edit foo.go with no Re-Read in (T2, T3)
 	//
 	// The Edit is based on a stale in-memory view of the file. The earlier
@@ -708,7 +708,7 @@ func (d *Detector) ruleStaleFileView(ctx context.Context, sessionID string) ([]A
 		`SELECT file_path, CAST(ts AS BIGINT) AS change_ms
 		 FROM tma1_external_changes
 		 WHERE file_path IN (%s)
-		   AND attribution = 'human'
+		   AND attribution IN ('human','unknown')
 		   AND change_type IN ('file_modified','file_added')
 		   AND ts > now() - INTERVAL '%d minutes'
 		 ORDER BY ts ASC`,
@@ -740,7 +740,7 @@ func (d *Detector) ruleStaleFileView(ctx context.Context, sessionID string) ([]A
 			Severity: SeverityHigh,
 			Channel:  ChannelUserPromptSubmit,
 			Evidence: fmt.Sprintf(
-				"You edited %s after a human modified it externally at %s, without re-reading first.",
+				"You edited %s after it changed externally at %s, without re-reading first.",
 				shortPath(fp), when.Format("15:04"),
 			),
 			Suggestion: fmt.Sprintf(
@@ -759,7 +759,7 @@ func (d *Detector) ruleStaleFileView(ctx context.Context, sessionID string) ([]A
 // Inputs are timestamps (ms) for one file in one session:
 //   - reads:   PreToolUse Read events
 //   - edits:   PreToolUse Edit/MultiEdit/Write events
-//   - changes: external human modifications on the same file
+//   - changes: modifications outside observed agent writes on the same file
 //
 // Returns the most recent change timestamp that triggered the rule, or 0
 // when no Edit was based on a stale view. An Edit triggers when there is
@@ -881,10 +881,10 @@ func (d *Detector) ruleTestStuck(ctx context.Context, sessionID string) ([]Anoma
 }
 
 // ───────────────────────────────────────────────────────────────────────
-// R-human-during — human-attributed changes during this session
+// R-external-during — changes outside observed agent writes during this session
 // ───────────────────────────────────────────────────────────────────────
 
-func (d *Detector) ruleHumanModifiedDuringSession(ctx context.Context, sessionID string) ([]Anomaly, error) {
+func (d *Detector) ruleExternalModifiedDuringSession(ctx context.Context, sessionID string) ([]Anomaly, error) {
 	winSQL := fmt.Sprintf(
 		`SELECT CAST(MIN(ts) AS BIGINT) AS start_ms,
 		        CAST(MAX(ts) AS BIGINT) AS end_ms,
@@ -918,7 +918,7 @@ func (d *Detector) ruleHumanModifiedDuringSession(ctx context.Context, sessionID
 	changesSQL := fmt.Sprintf(
 		`SELECT file_path FROM tma1_external_changes
 		 WHERE project = '%s'
-		   AND attribution = 'human'
+		   AND attribution IN ('human','unknown')
 		   AND change_type IN ('file_modified','file_added')
 		   AND ts > %d
 		   AND file_path IS NOT NULL AND file_path != ''
@@ -943,10 +943,10 @@ func (d *Detector) ruleHumanModifiedDuringSession(ctx context.Context, sessionID
 		preview = preview[:3]
 	}
 	return []Anomaly{{
-		Kind:         "human_modified_during_session",
+		Kind:         "external_modified_during_session",
 		Severity:     SeverityMedium,
 		Channel:      ChannelUserPromptSubmit,
-		Evidence:     fmt.Sprintf("A human modified %d file(s) in this project during this session (e.g. %s).", len(files), strings.Join(preview, ", ")),
+		Evidence:     fmt.Sprintf("%d file(s) changed outside observed agent writes during this session (e.g. %s).", len(files), strings.Join(preview, ", ")),
 		Suggestion:   "Re-read the listed files before assuming your in-memory copy is current.",
 		RelatedFiles: files,
 	}}, nil

--- a/server/internal/perception/bundle.go
+++ b/server/internal/perception/bundle.go
@@ -144,7 +144,7 @@ func (b *Bundler) BuildBundle(ctx context.Context, sessionID, cwd string) *Bundl
 		}
 		bundle.Build = status
 
-		// External changes: human-attributed file changes + git activity
+		// External changes: unattributed file changes + git activity
 		// in the last 30 minutes (the default window). Agent-attributed
 		// changes are filtered out by GetExternalChanges itself.
 		ext, err := b.GetExternalChanges(ctx, bundle.Project, time.Now().Add(-30*time.Minute))
@@ -329,16 +329,16 @@ func renderBuildBlock(sb *strings.Builder, bs *BuildStatus) {
 	}
 }
 
-// renderExternalBlock — human-attributed file changes + most recent git
+// renderExternalBlock — unattributed file changes + most recent git
 // event since the bundle's window.
 func renderExternalBlock(sb *strings.Builder, ext *ExternalChanges) {
-	if ext == nil || (ext.HumanCount == 0 && ext.GitCount == 0) {
+	if ext == nil || (ext.ExternalCount == 0 && ext.GitCount == 0) {
 		return
 	}
-	if ext.HumanCount > 0 {
-		fmt.Fprintf(sb, "external_human_changes: %d\n", ext.HumanCount)
+	if ext.ExternalCount > 0 {
+		fmt.Fprintf(sb, "external_changes: %d\n", ext.ExternalCount)
 		short := make([]string, 0, 3)
-		for i, c := range ext.HumanChanges {
+		for i, c := range ext.ExternalChanges {
 			if i >= 3 {
 				break
 			}

--- a/server/internal/perception/bundle_test.go
+++ b/server/internal/perception/bundle_test.go
@@ -84,6 +84,26 @@ func TestRenderSummaryIncludesKeyFields(t *testing.T) {
 	}
 }
 
+func TestRenderSummaryUsesExternalChangeWording(t *testing.T) {
+	b := &Bundle{
+		Project: "tma1",
+		External: &ExternalChanges{
+			ExternalCount: 1,
+			ExternalChanges: []ExternalChange{
+				{FilePath: "/repo/file.go", Attribution: "unknown"},
+			},
+		},
+	}
+
+	got := b.RenderSummary()
+	if !strings.Contains(got, "external_changes: 1") {
+		t.Fatalf("external change count missing: %q", got)
+	}
+	if strings.Contains(got, "human") {
+		t.Fatalf("external change summary claims a human source: %q", got)
+	}
+}
+
 func TestRenderSummaryStaysShort(t *testing.T) {
 	// 60 tools / 80 files would explode a naive renderer; the bundle should cap each.
 	state := &SessionState{

--- a/server/internal/perception/digest.go
+++ b/server/internal/perception/digest.go
@@ -120,11 +120,11 @@ func digestBuild(bs *BuildStatus) string {
 }
 
 func digestExternal(ec *ExternalChanges) string {
-	if ec == nil || (ec.HumanCount == 0 && ec.GitCount == 0) {
+	if ec == nil || (ec.ExternalCount == 0 && ec.GitCount == 0) {
 		return ""
 	}
-	paths := make([]string, 0, len(ec.HumanChanges))
-	for _, c := range ec.HumanChanges {
+	paths := make([]string, 0, len(ec.ExternalChanges))
+	for _, c := range ec.ExternalChanges {
 		paths = append(paths, c.ChangeType+":"+c.FilePath)
 	}
 	sort.Strings(paths)
@@ -160,4 +160,3 @@ func shortHash(s string) string {
 	h := sha256.Sum256([]byte(s))
 	return hex.EncodeToString(h[:8])
 }
-

--- a/server/internal/perception/external.go
+++ b/server/internal/perception/external.go
@@ -15,29 +15,29 @@ type ExternalChange struct {
 	FilePath    string    `json:"file_path,omitempty"`
 	GitSHA      string    `json:"git_sha,omitempty"`
 	GitMessage  string    `json:"git_message,omitempty"`
-	Attribution string    `json:"attribution,omitempty"` // agent | human | unknown
+	Attribution string    `json:"attribution,omitempty"` // agent | unknown; historical rows may contain human
 }
 
 // ExternalChanges is the summarised section for a Bundle.
 type ExternalChanges struct {
-	Project      string           `json:"project"`
-	Since        time.Time        `json:"since"`
-	HumanChanges []ExternalChange `json:"human_changes,omitempty"`
-	GitChanges   []ExternalChange `json:"git_changes,omitempty"`
-	HumanCount   int              `json:"human_count"`
-	GitCount     int              `json:"git_count"`
+	Project         string           `json:"project"`
+	Since           time.Time        `json:"since"`
+	ExternalChanges []ExternalChange `json:"external_changes,omitempty"`
+	GitChanges      []ExternalChange `json:"git_changes,omitempty"`
+	ExternalCount   int              `json:"external_count"`
+	GitCount        int              `json:"git_count"`
 	// PartialError is set when one of the two underlying queries
-	// (human-attribution / git-activity) failed but the other returned
+	// (external-file / git-activity) failed but the other returned
 	// rows. The MCP tool surfaces it alongside the partial result so
 	// callers know the snapshot is incomplete; the field stays empty
 	// (and is omitted from JSON) on a clean success.
 	PartialError string `json:"partial_error,omitempty"`
 }
 
-// GetExternalChanges returns the human-attributed file changes and git
+// GetExternalChanges returns file changes not attributed to an agent and git
 // activity for the given project since the given time. Agent-attributed
-// changes are deliberately filtered out — the agent doesn't need to be
-// told about edits it just made.
+// changes are filtered out because the agent doesn't need to be told about
+// edits it just made.
 //
 // Returns nil if there are no relevant changes.
 func (b *Bundler) GetExternalChanges(ctx context.Context, project string, since time.Time) (*ExternalChanges, error) {
@@ -50,18 +50,18 @@ func (b *Bundler) GetExternalChanges(ctx context.Context, project string, since 
 
 	out := &ExternalChanges{Project: project, Since: since}
 
-	// The human-attribution and git-activity queries are independent —
+	// The external-file and git-activity queries are independent —
 	// run them concurrently so the call latency is the slower of the two
 	// rather than their sum. Each query owns its own error variable
-	// (humanErr / gitErr), so partial failures surface without a mutex —
+	// (externalErr / gitErr), so partial failures surface without a mutex —
 	// the goroutines never write to the same memory location.
-	humanSQL := fmt.Sprintf(
+	externalSQL := fmt.Sprintf(
 		// CAST(...) must be aliased; otherwise GreptimeDB complains that
 		// two projected columns share the same name as the ORDER BY column.
 		`SELECT CAST(ts AS BIGINT) AS ts_ms, change_type, file_path, attribution
 		 FROM tma1_external_changes
 		 WHERE project = '%s'
-		   AND attribution = 'human'
+		   AND attribution IN ('human','unknown')
 		   AND change_type IN ('file_modified','file_added','file_deleted')
 		   AND ts > %d
 		 ORDER BY ts DESC LIMIT 20`,
@@ -78,27 +78,27 @@ func (b *Bundler) GetExternalChanges(ctx context.Context, project string, since 
 	)
 
 	var (
-		humanErr, gitErr error
-		wg               sync.WaitGroup
+		externalErr, gitErr error
+		wg                  sync.WaitGroup
 	)
 	wg.Add(2)
 
 	go func() {
 		defer wg.Done()
-		_, rows, err := b.client.Query(ctx, humanSQL)
+		_, rows, err := b.client.Query(ctx, externalSQL)
 		if err != nil {
-			humanErr = fmt.Errorf("human changes: %w", err)
+			externalErr = fmt.Errorf("external changes: %w", err)
 			return
 		}
 		for _, r := range rows {
-			out.HumanChanges = append(out.HumanChanges, ExternalChange{
+			out.ExternalChanges = append(out.ExternalChanges, ExternalChange{
 				Timestamp:   time.UnixMilli(int64At(r, 0)),
 				ChangeType:  stringAt(r, 1),
 				FilePath:    stringAt(r, 2),
 				Attribution: stringAt(r, 3),
 			})
 		}
-		out.HumanCount = len(out.HumanChanges)
+		out.ExternalCount = len(out.ExternalChanges)
 	}()
 
 	go func() {
@@ -125,10 +125,9 @@ func (b *Bundler) GetExternalChanges(ctx context.Context, project string, since 
 	// surface the error alongside the partial result. A caller relying on
 	// `err == nil ⇒ complete data` would otherwise treat a GreptimeDB
 	// outage as "no external changes", silencing the signal.
-	combinedErr := errors.Join(humanErr, gitErr)
-	if out.HumanCount == 0 && out.GitCount == 0 {
+	combinedErr := errors.Join(externalErr, gitErr)
+	if out.ExternalCount == 0 && out.GitCount == 0 {
 		return nil, combinedErr
 	}
 	return out, combinedErr
 }
-

--- a/server/internal/perception/external_test.go
+++ b/server/internal/perception/external_test.go
@@ -1,0 +1,68 @@
+package perception
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestGetExternalChangesIncludesUnknownAttribution(t *testing.T) {
+	bundler := NewBundler(1, nil)
+	var (
+		mu      sync.Mutex
+		queries []string
+	)
+	bundler.client.http = &http.Client{Transport: externalRoundTripFunc(func(r *http.Request) (*http.Response, error) {
+		if err := r.ParseForm(); err != nil {
+			return nil, err
+		}
+		sql := r.Form.Get("sql")
+		mu.Lock()
+		queries = append(queries, sql)
+		mu.Unlock()
+
+		rows := "[]"
+		if strings.Contains(sql, "file_modified") {
+			rows = `[[1000,"file_modified","/repo/file.go","unknown"]]`
+		}
+		body := `{"code":0,"output":[{"records":{"rows":` + rows + `}}]}`
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(body)),
+		}, nil
+	})}
+
+	changes, err := bundler.GetExternalChanges(context.Background(), "tma1", time.UnixMilli(1))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if changes == nil || changes.ExternalCount != 1 || len(changes.ExternalChanges) != 1 {
+		t.Fatalf("unexpected external changes: %+v", changes)
+	}
+	if changes.ExternalChanges[0].Attribution != "unknown" {
+		t.Fatalf("attribution = %q, want unknown", changes.ExternalChanges[0].Attribution)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	found := false
+	for _, sql := range queries {
+		if strings.Contains(sql, "attribution IN ('human','unknown')") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("external query did not include unknown attribution: %v", queries)
+	}
+}
+
+type externalRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f externalRoundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return f(r)
+}

--- a/server/internal/perception/file_writer.go
+++ b/server/internal/perception/file_writer.go
@@ -115,11 +115,11 @@ func renderMarkdown(b *Bundle) string {
 		fmt.Fprintf(&sb, "Project: **%s**\n\n", b.Project)
 	}
 
-	if ext := b.External; ext != nil && (ext.HumanCount > 0 || ext.GitCount > 0) {
+	if ext := b.External; ext != nil && (ext.ExternalCount > 0 || ext.GitCount > 0) {
 		sb.WriteString("## External changes (last 30 min)\n\n")
-		if ext.HumanCount > 0 {
-			fmt.Fprintf(&sb, "Human modified %d file(s):\n", ext.HumanCount)
-			for i, c := range ext.HumanChanges {
+		if ext.ExternalCount > 0 {
+			fmt.Fprintf(&sb, "%d file(s) changed outside observed agent writes:\n", ext.ExternalCount)
+			for i, c := range ext.ExternalChanges {
 				if i >= 8 {
 					break
 				}

--- a/server/internal/sensor/git/attribution.go
+++ b/server/internal/sensor/git/attribution.go
@@ -66,7 +66,7 @@ func (a *HookAttributor) Classify(ctx context.Context, projectRoot, filePath str
 	if a.httpPort <= 0 || projectRoot == "" || filePath == "" {
 		return AttributionUnknown
 	}
-	root := strings.TrimRight(projectRoot, `/\\`)
+	root := strings.TrimRight(projectRoot, `/\`)
 	if root == "" {
 		return AttributionUnknown
 	}

--- a/server/internal/sensor/git/attribution.go
+++ b/server/internal/sensor/git/attribution.go
@@ -14,12 +14,12 @@ import (
 	"github.com/tma1-ai/tma1/server/internal/sqlutil"
 )
 
-// AttributionWindow bounds exact file-path correlation around an fsnotify event.
+// AttributionWindow bounds exact file-path correlation before an fsnotify event.
 const AttributionWindow = 5 * time.Second
 
 // activeToolLookback bounds the scan for a tool invocation that was still
-// running when fsnotify delivered the change. Unmatched changes remain unknown,
-// so an invocation older than this cannot turn into a false human attribution.
+// running when fsnotify delivered the change. Older invocations cannot be
+// mistaken for active tools.
 const activeToolLookback = 30 * time.Minute
 
 // activeToolCacheTTL coalesces the burst of per-path fsnotify events produced
@@ -42,7 +42,6 @@ type HookAttributor struct {
 
 type activeToolCacheEntry struct {
 	checkedAt time.Time
-	active    bool
 }
 
 // NewHookAttributor returns an Attributor querying GreptimeDB on localhost:<httpPort>.
@@ -57,8 +56,8 @@ func NewHookAttributor(httpPort int) *HookAttributor {
 // Classify returns "agent" when hook data ties a file change to agent activity.
 // The signal sources are, in order:
 //
-//  1. A recent PreToolUse whose extracted file path matches exactly.
-//  2. A tool running in the same project when fsnotify delivered the change.
+//  1. A recent mutating PreToolUse whose extracted file path matches exactly.
+//  2. A mutating tool running in the same project when fsnotify delivered the change.
 //
 // Hook telemetry cannot prove that an unmatched change came from a human.
 // Missing evidence and query failures therefore return "unknown".
@@ -70,21 +69,24 @@ func (a *HookAttributor) Classify(ctx context.Context, projectRoot, filePath str
 	if root == "" {
 		return AttributionUnknown
 	}
-	if active, ok := a.cachedActiveTool(root); ok && active {
+	if a.cachedActiveTool(root) {
 		return AttributionAgent
 	}
 	low := when.Add(-AttributionWindow).UnixMilli()
-	high := when.Add(AttributionWindow).UnixMilli()
+	high := when.UnixMilli()
 
 	// Prefer the ingest-side tool_file_path column; fall back to extraction
-	// for rows written before the derived column was introduced.
+	// for rows written before the derived column was introduced. Read-only
+	// tools are excluded because reading a path is not evidence that the agent
+	// caused a concurrent write to it.
 	editSQL := fmt.Sprintf(
 		`SELECT COUNT(*) FROM tma1_hook_events
 		 WHERE event_type = 'PreToolUse'
 		   AND ts BETWEEN %d AND %d
+		   AND %s
 		   AND COALESCE(tool_file_path,
 		                regexp_match(tool_input, '"file_path":"([^"]+)"')[1]) = '%s'`,
-		low, high, escapeSQLLiteral(filePath),
+		low, high, mutatingToolPredicate("tool_name"), escapeSQLLiteral(filePath),
 	)
 	if count, err := a.queryCount(ctx, editSQL); err != nil {
 		return AttributionUnknown
@@ -95,15 +97,10 @@ func (a *HookAttributor) Classify(ctx context.Context, projectRoot, filePath str
 	// Indirect writes such as builds, git commands, screenshot tools, and
 	// atomic-save temporary files often do not name every changed path. Pair
 	// PreToolUse/PostToolUse by tool_use_id and only consider invocations whose
-	// cwd is the watched project or one of its subdirectories.
+	// cwd is the watched project or one of its subdirectories. Stop and
+	// SessionEnd close orphaned tool calls left by interruption or cancellation.
 	activeLow := when.Add(-activeToolLookback).UnixMilli()
 	activeHigh := when.UnixMilli()
-	if active, ok := a.cachedActiveTool(root); ok {
-		if active {
-			return AttributionAgent
-		}
-		return AttributionUnknown
-	}
 	activeSQL := fmt.Sprintf(
 		`SELECT COUNT(*) FROM tma1_hook_events p
 		 LEFT JOIN tma1_hook_events q
@@ -112,13 +109,24 @@ func (a *HookAttributor) Classify(ctx context.Context, projectRoot, filePath str
 		  AND q.tool_use_id = p.tool_use_id
 		  AND q.event_type IN ('PostToolUse','PostToolUseFailure')
 		  AND q.ts >= p.ts
-		  AND CAST(q.ts AS BIGINT) <= %d
+		  AND q.ts BETWEEN %d AND %d
+		 LEFT JOIN tma1_hook_events s
+		   ON s.agent_source = p.agent_source
+		  AND s.session_id = p.session_id
+		  AND s.event_type IN ('Stop','SessionEnd')
+		  AND s.ts >= p.ts
+		  AND s.ts BETWEEN %d AND %d
 		 WHERE p.event_type = 'PreToolUse'
 		   AND p.tool_use_id IS NOT NULL AND p.tool_use_id != ''
 		   AND p.ts BETWEEN %d AND %d
+		   AND %s
 		   AND (p.cwd = '%s' OR p.cwd LIKE '%s/%%' OR p.cwd LIKE '%s\\%%')
-		   AND q.tool_use_id IS NULL`,
-		activeHigh, activeLow, activeHigh,
+		   AND q.tool_use_id IS NULL
+		   AND s.session_id IS NULL`,
+		activeLow, activeHigh,
+		activeLow, activeHigh,
+		activeLow, activeHigh,
+		mutatingToolPredicate("p.tool_name"),
 		escapeSQLLiteral(root),
 		escapeSQLLikeLiteral(root),
 		escapeSQLLikeLiteral(root),
@@ -127,28 +135,38 @@ func (a *HookAttributor) Classify(ctx context.Context, projectRoot, filePath str
 	if err != nil {
 		return AttributionUnknown
 	}
-	a.storeActiveTool(root, count > 0)
 	if count > 0 {
+		a.storeActiveTool(root)
 		return AttributionAgent
 	}
 
 	return AttributionUnknown
 }
 
-func (a *HookAttributor) cachedActiveTool(root string) (bool, bool) {
+func (a *HookAttributor) cachedActiveTool(root string) bool {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	entry, ok := a.active[root]
 	if !ok || time.Since(entry.checkedAt) >= activeToolCacheTTL {
-		return false, false
+		return false
 	}
-	return entry.active, true
+	return true
 }
 
-func (a *HookAttributor) storeActiveTool(root string, active bool) {
+func (a *HookAttributor) storeActiveTool(root string) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
-	a.active[root] = activeToolCacheEntry{checkedAt: time.Now(), active: active}
+	a.active[root] = activeToolCacheEntry{checkedAt: time.Now()}
+}
+
+// mutatingToolPredicate returns a positive capability check. Unknown tools are
+// not treated as writers: failing to recognize a tool may produce an external
+// warning, but it cannot hide a real external modification as agent-caused.
+func mutatingToolPredicate(column string) string {
+	return fmt.Sprintf(
+		`LOWER(%[1]s) IN ('edit','write','multiedit','notebookedit','bash','shell','exec','exec_command','apply_patch','mcp__plugin_playwright_playwright__browser_take_screenshot')`,
+		column,
+	)
 }
 
 func (a *HookAttributor) queryCount(ctx context.Context, sql string) (int, error) {

--- a/server/internal/sensor/git/attribution.go
+++ b/server/internal/sensor/git/attribution.go
@@ -97,6 +97,7 @@ func (a *HookAttributor) Classify(ctx context.Context, projectRoot, filePath str
 	// PreToolUse/PostToolUse by tool_use_id and only consider invocations whose
 	// cwd is the watched project or one of its subdirectories.
 	activeLow := when.Add(-activeToolLookback).UnixMilli()
+	activeHigh := when.UnixMilli()
 	if active, ok := a.cachedActiveTool(root); ok {
 		if active {
 			return AttributionAgent
@@ -111,12 +112,13 @@ func (a *HookAttributor) Classify(ctx context.Context, projectRoot, filePath str
 		  AND q.tool_use_id = p.tool_use_id
 		  AND q.event_type IN ('PostToolUse','PostToolUseFailure')
 		  AND q.ts >= p.ts
+		  AND CAST(q.ts AS BIGINT) <= %d
 		 WHERE p.event_type = 'PreToolUse'
 		   AND p.tool_use_id IS NOT NULL AND p.tool_use_id != ''
 		   AND p.ts BETWEEN %d AND %d
 		   AND (p.cwd = '%s' OR p.cwd LIKE '%s/%%' OR p.cwd LIKE '%s\\%%')
 		   AND q.tool_use_id IS NULL`,
-		activeLow, high,
+		activeHigh, activeLow, activeHigh,
 		escapeSQLLiteral(root),
 		escapeSQLLikeLiteral(root),
 		escapeSQLLikeLiteral(root),

--- a/server/internal/sensor/git/attribution.go
+++ b/server/internal/sensor/git/attribution.go
@@ -8,21 +8,27 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 
-	"github.com/tma1-ai/tma1/server/internal/pathutil"
 	"github.com/tma1-ai/tma1/server/internal/sqlutil"
 )
 
-// AttributionWindow is the ±window we look at hook events to classify a
-// file change as agent-caused. Plan §Phase 1.2 uses ±5s — short enough
-// that human typing isn't mistakenly attributed to the agent, generous
-// enough that fsnotify's delivery lag still falls inside it.
+// AttributionWindow bounds exact file-path correlation around an fsnotify event.
 const AttributionWindow = 5 * time.Second
 
-// HookAttributor classifies file changes by querying tma1_hook_events for a
-// recent Edit/Write/MultiEdit on the same file_path. It's the production
-// implementation of Attributor used by the git sensor.
+// activeToolLookback bounds the scan for a tool invocation that was still
+// running when fsnotify delivered the change. Unmatched changes remain unknown,
+// so an invocation older than this cannot turn into a false human attribution.
+const activeToolLookback = 30 * time.Minute
+
+// activeToolCacheTTL coalesces the burst of per-path fsnotify events produced
+// by one tool without keeping a stale attribution across normal user actions.
+const activeToolCacheTTL = 250 * time.Millisecond
+
+// HookAttributor classifies file changes by correlating them with
+// tma1_hook_events. It's the production implementation of Attributor used by
+// the git sensor.
 //
 // It's deliberately a self-contained struct (no perception import) so the
 // sensor package doesn't depend on perception, which would create a cycle
@@ -30,6 +36,13 @@ const AttributionWindow = 5 * time.Second
 type HookAttributor struct {
 	httpPort int
 	http     *http.Client
+	mu       sync.Mutex
+	active   map[string]activeToolCacheEntry
+}
+
+type activeToolCacheEntry struct {
+	checkedAt time.Time
+	active    bool
 }
 
 // NewHookAttributor returns an Attributor querying GreptimeDB on localhost:<httpPort>.
@@ -37,34 +50,37 @@ func NewHookAttributor(httpPort int) *HookAttributor {
 	return &HookAttributor{
 		httpPort: httpPort,
 		http:     &http.Client{Timeout: 1500 * time.Millisecond},
+		active:   make(map[string]activeToolCacheEntry),
 	}
 }
 
-// Classify returns "agent" if any hook event within ±AttributionWindow of
-// `when` plausibly touched filePath. The signal sources are, in order:
+// Classify returns "agent" when hook data ties a file change to agent activity.
+// The signal sources are, in order:
 //
-//  1. Edit / Write / MultiEdit whose tool_input.file_path matches exactly.
-//  2. Bash whose tool_input.command contains the file's basename.
-//     This catches mkdir/rm/touch/cp/mv/git checkout/etc., which the
-//     git sensor would otherwise mis-attribute to a human because the
-//     hook event has no file_path field.
+//  1. A recent PreToolUse whose extracted file path matches exactly.
+//  2. A tool running in the same project when fsnotify delivered the change.
 //
-// Otherwise "human" (safe default — we over-credit humans rather than
-// wrongly absolve the agent). On query error returns "unknown".
-func (a *HookAttributor) Classify(ctx context.Context, filePath string, when time.Time) string {
-	if a.httpPort <= 0 || filePath == "" {
+// Hook telemetry cannot prove that an unmatched change came from a human.
+// Missing evidence and query failures therefore return "unknown".
+func (a *HookAttributor) Classify(ctx context.Context, projectRoot, filePath string, when time.Time) string {
+	if a.httpPort <= 0 || projectRoot == "" || filePath == "" {
 		return AttributionUnknown
+	}
+	root := strings.TrimRight(projectRoot, `/\\`)
+	if root == "" {
+		return AttributionUnknown
+	}
+	if active, ok := a.cachedActiveTool(root); ok && active {
+		return AttributionAgent
 	}
 	low := when.Add(-AttributionWindow).UnixMilli()
 	high := when.Add(AttributionWindow).UnixMilli()
 
-	// Pass 1: explicit Edit/Write/MultiEdit on this exact file_path.
-	// Prefer the ingest-side tool_file_path column; fall back to regex
-	// lift for rows written before Phase 1.4.
+	// Prefer the ingest-side tool_file_path column; fall back to extraction
+	// for rows written before the derived column was introduced.
 	editSQL := fmt.Sprintf(
 		`SELECT COUNT(*) FROM tma1_hook_events
 		 WHERE event_type = 'PreToolUse'
-		   AND tool_name IN ('Edit','Write','MultiEdit')
 		   AND ts BETWEEN %d AND %d
 		   AND COALESCE(tool_file_path,
 		                regexp_match(tool_input, '"file_path":"([^"]+)"')[1]) = '%s'`,
@@ -76,37 +92,61 @@ func (a *HookAttributor) Classify(ctx context.Context, filePath string, when tim
 		return AttributionAgent
 	}
 
-	// Pass 2: Bash command whose tool_input mentions the file's basename.
-	// LIKE is loose (substring match anywhere) which is precisely what we
-	// want — e.g. `git checkout server/internal/foo.go` puts the path
-	// inside a longer string, and `mkdir cmd/render-since` puts only the
-	// final segment.
-	base := basenameOf(filePath)
-	if base == "" {
-		return AttributionHuman
-	}
-	bashSQL := fmt.Sprintf(
-		`SELECT COUNT(*) FROM tma1_hook_events
-		 WHERE event_type = 'PreToolUse'
-		   AND tool_name = 'Bash'
-		   AND ts BETWEEN %d AND %d
-		   AND tool_input LIKE '%%%s%%'`,
-		low, high, escapeSQLLikeLiteral(base),
-	)
-	if count, err := a.queryCount(ctx, bashSQL); err != nil {
+	// Indirect writes such as builds, git commands, screenshot tools, and
+	// atomic-save temporary files often do not name every changed path. Pair
+	// PreToolUse/PostToolUse by tool_use_id and only consider invocations whose
+	// cwd is the watched project or one of its subdirectories.
+	activeLow := when.Add(-activeToolLookback).UnixMilli()
+	if active, ok := a.cachedActiveTool(root); ok {
+		if active {
+			return AttributionAgent
+		}
 		return AttributionUnknown
-	} else if count > 0 {
+	}
+	activeSQL := fmt.Sprintf(
+		`SELECT COUNT(*) FROM tma1_hook_events p
+		 LEFT JOIN tma1_hook_events q
+		   ON q.agent_source = p.agent_source
+		  AND q.session_id = p.session_id
+		  AND q.tool_use_id = p.tool_use_id
+		  AND q.event_type IN ('PostToolUse','PostToolUseFailure')
+		  AND q.ts >= p.ts
+		 WHERE p.event_type = 'PreToolUse'
+		   AND p.tool_use_id IS NOT NULL AND p.tool_use_id != ''
+		   AND p.ts BETWEEN %d AND %d
+		   AND (p.cwd = '%s' OR p.cwd LIKE '%s/%%' OR p.cwd LIKE '%s\\%%')
+		   AND q.tool_use_id IS NULL`,
+		activeLow, high,
+		escapeSQLLiteral(root),
+		escapeSQLLikeLiteral(root),
+		escapeSQLLikeLiteral(root),
+	)
+	count, err := a.queryCount(ctx, activeSQL)
+	if err != nil {
+		return AttributionUnknown
+	}
+	a.storeActiveTool(root, count > 0)
+	if count > 0 {
 		return AttributionAgent
 	}
 
-	return AttributionHuman
+	return AttributionUnknown
 }
 
-// basenameOf returns the last path segment of p ("/a/b/c.go" → "c.go").
-// pathutil handles both POSIX and Windows separators because file_path
-// values come from agents on any OS.
-func basenameOf(p string) string {
-	return pathutil.Basename(p)
+func (a *HookAttributor) cachedActiveTool(root string) (bool, bool) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	entry, ok := a.active[root]
+	if !ok || time.Since(entry.checkedAt) >= activeToolCacheTTL {
+		return false, false
+	}
+	return entry.active, true
+}
+
+func (a *HookAttributor) storeActiveTool(root string, active bool) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.active[root] = activeToolCacheEntry{checkedAt: time.Now(), active: active}
 }
 
 func (a *HookAttributor) queryCount(ctx context.Context, sql string) (int, error) {

--- a/server/internal/sensor/git/attribution_test.go
+++ b/server/internal/sensor/git/attribution_test.go
@@ -10,7 +10,7 @@ import (
 	"time"
 )
 
-func TestHookAttributorUsesExactPathFromAnyTool(t *testing.T) {
+func TestHookAttributorUsesExactPathFromMutatingTool(t *testing.T) {
 	attributor, queries := newCountingAttributor(t, 1)
 
 	got := attributor.Classify(context.Background(), "/repo/tma1", "/repo/tma1/output.png", time.UnixMilli(10_000))
@@ -20,8 +20,8 @@ func TestHookAttributorUsesExactPathFromAnyTool(t *testing.T) {
 	if len(*queries) != 1 {
 		t.Fatalf("queries = %d, want 1", len(*queries))
 	}
-	if strings.Contains((*queries)[0], "tool_name IN") {
-		t.Fatalf("exact path attribution must not be limited to hard-coded tool names: %s", (*queries)[0])
+	if !strings.Contains((*queries)[0], "LOWER(tool_name) IN") {
+		t.Fatalf("exact path attribution must require a mutating tool: %s", (*queries)[0])
 	}
 }
 
@@ -40,22 +40,18 @@ func TestHookAttributorUsesActiveProjectToolForIndirectWrite(t *testing.T) {
 		"LEFT JOIN tma1_hook_events q",
 		"q.tool_use_id = p.tool_use_id",
 		"q.event_type IN ('PostToolUse','PostToolUseFailure')",
-		"CAST(q.ts AS BIGINT) <= 10000",
+		"q.ts BETWEEN -1790000 AND 10000",
+		"s.event_type IN ('Stop','SessionEnd')",
+		"s.ts BETWEEN -1790000 AND 10000",
 		"p.ts BETWEEN -1790000 AND 10000",
+		"LOWER(p.tool_name) IN",
 		"p.cwd = '/repo/tma1'",
 		"q.tool_use_id IS NULL",
+		"s.session_id IS NULL",
 	} {
 		if !strings.Contains(activeSQL, fragment) {
 			t.Errorf("active-tool query missing %q: %s", fragment, activeSQL)
 		}
-	}
-
-	got = attributor.Classify(context.Background(), "/repo/tma1", "/repo/tma1/generated/other.go", time.UnixMilli(10_001))
-	if got != AttributionAgent {
-		t.Fatalf("cached Classify() = %q, want %q", got, AttributionAgent)
-	}
-	if len(*queries) != 2 {
-		t.Fatalf("cached classification issued another query; queries = %d, want 2", len(*queries))
 	}
 }
 
@@ -65,6 +61,33 @@ func TestHookAttributorDoesNotInferHumanFromMissingHookEvidence(t *testing.T) {
 	got := attributor.Classify(context.Background(), "/repo/tma1", "/repo/tma1/notes.txt", time.UnixMilli(10_000))
 	if got != AttributionUnknown {
 		t.Fatalf("Classify() = %q, want %q", got, AttributionUnknown)
+	}
+}
+
+func TestMutatingToolPredicateExcludesReadOnlyAndInteractiveTools(t *testing.T) {
+	predicate := strings.ToLower(mutatingToolPredicate("tool_name"))
+	for _, name := range []string{"read", "grep", "glob", "askuserquestion", "exitplanmode"} {
+		if strings.Contains(predicate, "'"+name+"'") {
+			t.Errorf("mutating predicate contains non-mutating tool %q: %s", name, predicate)
+		}
+	}
+	for _, name := range []string{"edit", "write", "bash", "exec_command", "apply_patch"} {
+		if !strings.Contains(predicate, "'"+name+"'") {
+			t.Errorf("mutating predicate missing tool %q: %s", name, predicate)
+		}
+	}
+}
+
+func TestHookAttributorActiveCacheExpiry(t *testing.T) {
+	attributor := NewHookAttributor(1)
+	attributor.active["fresh"] = activeToolCacheEntry{checkedAt: time.Now().Add(time.Minute)}
+	attributor.active["expired"] = activeToolCacheEntry{checkedAt: time.Now().Add(-time.Minute)}
+
+	if !attributor.cachedActiveTool("fresh") {
+		t.Fatal("future cache entry should be active")
+	}
+	if attributor.cachedActiveTool("expired") {
+		t.Fatal("expired cache entry should be inactive")
 	}
 }
 

--- a/server/internal/sensor/git/attribution_test.go
+++ b/server/internal/sensor/git/attribution_test.go
@@ -1,0 +1,100 @@
+package git
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestHookAttributorUsesExactPathFromAnyTool(t *testing.T) {
+	attributor, queries := newCountingAttributor(t, 1)
+
+	got := attributor.Classify(context.Background(), "/repo/tma1", "/repo/tma1/output.png", time.UnixMilli(10_000))
+	if got != AttributionAgent {
+		t.Fatalf("Classify() = %q, want %q", got, AttributionAgent)
+	}
+	if len(*queries) != 1 {
+		t.Fatalf("queries = %d, want 1", len(*queries))
+	}
+	if strings.Contains((*queries)[0], "tool_name IN") {
+		t.Fatalf("exact path attribution must not be limited to hard-coded tool names: %s", (*queries)[0])
+	}
+}
+
+func TestHookAttributorUsesActiveProjectToolForIndirectWrite(t *testing.T) {
+	attributor, queries := newCountingAttributor(t, 0, 1)
+
+	got := attributor.Classify(context.Background(), "/repo/tma1", "/repo/tma1/generated/file.go", time.UnixMilli(10_000))
+	if got != AttributionAgent {
+		t.Fatalf("Classify() = %q, want %q", got, AttributionAgent)
+	}
+	if len(*queries) != 2 {
+		t.Fatalf("queries = %d, want 2", len(*queries))
+	}
+	activeSQL := (*queries)[1]
+	for _, fragment := range []string{
+		"LEFT JOIN tma1_hook_events q",
+		"q.tool_use_id = p.tool_use_id",
+		"q.event_type IN ('PostToolUse','PostToolUseFailure')",
+		"p.cwd = '/repo/tma1'",
+		"q.tool_use_id IS NULL",
+	} {
+		if !strings.Contains(activeSQL, fragment) {
+			t.Errorf("active-tool query missing %q: %s", fragment, activeSQL)
+		}
+	}
+
+	got = attributor.Classify(context.Background(), "/repo/tma1", "/repo/tma1/generated/other.go", time.UnixMilli(10_001))
+	if got != AttributionAgent {
+		t.Fatalf("cached Classify() = %q, want %q", got, AttributionAgent)
+	}
+	if len(*queries) != 2 {
+		t.Fatalf("cached classification issued another query; queries = %d, want 2", len(*queries))
+	}
+}
+
+func TestHookAttributorDoesNotInferHumanFromMissingHookEvidence(t *testing.T) {
+	attributor, _ := newCountingAttributor(t, 0, 0)
+
+	got := attributor.Classify(context.Background(), "/repo/tma1", "/repo/tma1/notes.txt", time.UnixMilli(10_000))
+	if got != AttributionUnknown {
+		t.Fatalf("Classify() = %q, want %q", got, AttributionUnknown)
+	}
+}
+
+func newCountingAttributor(t *testing.T, counts ...int) (*HookAttributor, *[]string) {
+	t.Helper()
+	queries := make([]string, 0, len(counts))
+	attributor := NewHookAttributor(1)
+	attributor.http = &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		if err := r.ParseForm(); err != nil {
+			return nil, err
+		}
+		queries = append(queries, r.Form.Get("sql"))
+		call := len(queries) - 1
+		if call >= len(counts) {
+			t.Errorf("unexpected query %d: %s", call+1, queries[call])
+			return &http.Response{
+				StatusCode: http.StatusInternalServerError,
+				Body:       io.NopCloser(strings.NewReader("unexpected query")),
+			}, nil
+		}
+		body := fmt.Sprintf(`{"code":0,"output":[{"records":{"rows":[[%d]]}}]}`, counts[call])
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(body)),
+		}, nil
+	})}
+
+	return attributor, &queries
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return f(r)
+}

--- a/server/internal/sensor/git/attribution_test.go
+++ b/server/internal/sensor/git/attribution_test.go
@@ -40,6 +40,8 @@ func TestHookAttributorUsesActiveProjectToolForIndirectWrite(t *testing.T) {
 		"LEFT JOIN tma1_hook_events q",
 		"q.tool_use_id = p.tool_use_id",
 		"q.event_type IN ('PostToolUse','PostToolUseFailure')",
+		"CAST(q.ts AS BIGINT) <= 10000",
+		"p.ts BETWEEN -1790000 AND 10000",
 		"p.cwd = '/repo/tma1'",
 		"q.tool_use_id IS NULL",
 	} {

--- a/server/internal/sensor/git/event.go
+++ b/server/internal/sensor/git/event.go
@@ -48,7 +48,7 @@ type EventWriter interface {
 	Write(ctx context.Context, c Change) error
 }
 
-// Attributor decides whether a file change came from the agent or a human.
+// Attributor correlates a file change with available agent hook evidence.
 type Attributor interface {
-	Classify(ctx context.Context, filePath string, when time.Time) string
+	Classify(ctx context.Context, projectRoot, filePath string, when time.Time) string
 }

--- a/server/internal/sensor/git/event.go
+++ b/server/internal/sensor/git/event.go
@@ -3,8 +3,8 @@
 // (fsnotify) and polls `git log -1` so the perception layer can answer
 // "what changed outside of the agent's edits?".
 //
-// Storage is tma1_external_changes (one row per change). Attribution
-// (agent vs human) is decided at write time by querying tma1_hook_events.
+// Storage is tma1_external_changes (one row per change). Agent attribution
+// is decided at write time by querying tma1_hook_events.
 package git
 
 import (
@@ -25,7 +25,6 @@ const (
 // Attribution constants for the attribution column.
 const (
 	AttributionAgent   = "agent"
-	AttributionHuman   = "human"
 	AttributionUnknown = "unknown"
 )
 
@@ -38,7 +37,7 @@ type Change struct {
 	FilePath    string
 	GitSHA      string
 	GitMessage  string
-	Attribution string // agent | human | unknown
+	Attribution string // agent | unknown
 	Host        string
 }
 

--- a/server/internal/sensor/git/sensor_test.go
+++ b/server/internal/sensor/git/sensor_test.go
@@ -40,7 +40,7 @@ func TestSensorObserveIsIdempotent(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	sensor := NewSensor(&stubWriter{}, stubAttributor{AttributionHuman}, nil)
+	sensor := NewSensor(&stubWriter{}, stubAttributor{AttributionUnknown}, nil)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	sensor.Start(ctx)
@@ -60,7 +60,7 @@ func TestSensorObserveSkipsBeforeStart(t *testing.T) {
 	root := t.TempDir()
 	_ = os.MkdirAll(filepath.Join(root, ".git"), 0o755)
 
-	sensor := NewSensor(&stubWriter{}, stubAttributor{AttributionHuman}, nil)
+	sensor := NewSensor(&stubWriter{}, stubAttributor{AttributionUnknown}, nil)
 	sensor.Observe(root) // Start not yet called → must no-op
 
 	sensor.mu.Lock()
@@ -77,7 +77,7 @@ func TestSensorObserveDetectsRealFileWrite(t *testing.T) {
 	}
 
 	writer := &stubWriter{}
-	sensor := NewSensor(writer, stubAttributor{AttributionHuman}, nil)
+	sensor := NewSensor(writer, stubAttributor{AttributionUnknown}, nil)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	sensor.Start(ctx)
@@ -109,8 +109,8 @@ func TestSensorObserveDetectsRealFileWrite(t *testing.T) {
 	for _, c := range writer.events {
 		if c.FilePath == target {
 			saw = true
-			if c.Attribution != AttributionHuman {
-				t.Errorf("attribution = %q, want %q", c.Attribution, AttributionHuman)
+			if c.Attribution != AttributionUnknown {
+				t.Errorf("attribution = %q, want %q", c.Attribution, AttributionUnknown)
 			}
 			break
 		}

--- a/server/internal/sensor/git/sensor_test.go
+++ b/server/internal/sensor/git/sensor_test.go
@@ -30,7 +30,7 @@ func (s *stubWriter) count() int {
 
 type stubAttributor struct{ verdict string }
 
-func (s stubAttributor) Classify(_ context.Context, _ string, _ time.Time) string {
+func (s stubAttributor) Classify(_ context.Context, _, _ string, _ time.Time) string {
 	return s.verdict
 }
 

--- a/server/internal/sensor/git/watcher.go
+++ b/server/internal/sensor/git/watcher.go
@@ -189,7 +189,7 @@ func (w *projectWatcher) handleFsEvent(ev fsnotify.Event) {
 	}
 	change.Attribution = AttributionUnknown
 	if w.cfg.Attributor != nil {
-		change.Attribution = w.cfg.Attributor.Classify(w.ctx, ev.Name, change.Timestamp)
+		change.Attribution = w.cfg.Attributor.Classify(w.ctx, w.cfg.Root, ev.Name, change.Timestamp)
 	}
 
 	if err := w.cfg.Writer.Write(w.ctx, change); err != nil {

--- a/server/internal/sensor/git/watcher.go
+++ b/server/internal/sensor/git/watcher.go
@@ -252,7 +252,7 @@ func (w *projectWatcher) pollGit() {
 			ChangeType:  ChangeTypeGitBranchSwitch,
 			GitSHA:      sha,
 			GitMessage:  "branch: " + w.lastGitBranch + " → " + branch,
-			Attribution: AttributionHuman, // git commands ≈ human by default
+			Attribution: AttributionUnknown,
 			Host:        w.cfg.Host,
 		})
 		w.lastGitBranch = branch
@@ -267,7 +267,7 @@ func (w *projectWatcher) pollGit() {
 			ChangeType:  ChangeTypeGitCommit,
 			GitSHA:      sha,
 			GitMessage:  msg,
-			Attribution: AttributionHuman,
+			Attribution: AttributionUnknown,
 			Host:        w.cfg.Host,
 		})
 	}

--- a/site/src/i18n/ui.ts
+++ b/site/src/i18n/ui.ts
@@ -111,7 +111,7 @@ export const en: T = {
       {
         kind: 'stale_file_view',
         severity: 'HIGH',
-        narrative: 'A human edited the same file the agent was about to overwrite.',
+        narrative: 'The file changed outside observed agent writes before the agent edited it.',
         // verbatim — do not translate (anomaly.go::stale_file_view)
         suggestion: 'Re-read auth.go before the next edit — your in-memory copy is older than what’s on disk.',
         footer: 'injected into next user_prompt_submit',
@@ -345,7 +345,7 @@ export const es: T = {
       {
         kind: 'stale_file_view',
         severity: 'HIGH',
-        narrative: 'Un humano editó el mismo archivo que el agente estaba por sobrescribir.',
+        narrative: 'El archivo cambió fuera de las escrituras observadas del agente antes de que el agente lo editara.',
         // verbatim — do not translate
         suggestion: 'Re-read auth.go before the next edit — your in-memory copy is older than what’s on disk.',
         footer: 'injected into next user_prompt_submit',


### PR DESCRIPTION
## Summary

- Attribute file changes to the agent only when a recognized mutating tool matches the exact path or was active in the watched project.
- Bound active-tool lifecycle queries and close orphaned calls on `Stop` / `SessionEnd`, avoiding stale interactive-tool attribution.
- Keep unmatched file changes observable as `unknown` / external, including historical `human` rows, and update context, anomaly, MCP, and documentation terminology.
- Cache only positive active-tool results for 250 ms to coalesce fsnotify bursts without hiding newly started tools.

## Testing

- `make test`
- `make vet`
- `make lint`
- `git diff --check`
- Executed the bounded active-tool query against the local GreptimeDB instance.